### PR TITLE
Update to use "Recipes" instead of "Examples"

### DIFF
--- a/.github/actions/cpu-setup/action.yml
+++ b/.github/actions/cpu-setup/action.yml
@@ -1,4 +1,4 @@
-name: Olive Examples CI | Setup Composite Workflow for CPU runs
+name: Olive Recipes CI | Setup Composite Workflow for CPU runs
 description: "Composite action to setup environment for CPU workflows"
 
 inputs:

--- a/.github/actions/cuda-setup/action.yml
+++ b/.github/actions/cuda-setup/action.yml
@@ -1,4 +1,4 @@
-name: Olive Examples CI | Setup Composite Workflow for CUDA runs
+name: Olive Recipes CI | Setup Composite Workflow for CUDA runs
 description: "Composite action to setup environment for CUDA workflows"
 
 inputs:

--- a/.github/scripts/generate_matrix.py
+++ b/.github/scripts/generate_matrix.py
@@ -22,7 +22,7 @@ dirpath = Path(sys.argv[1])
 os = sys.argv[2]
 device = sys.argv[3]
 
-examples = []
+recipes = []
 for filepath in dirpath.rglob("olive_ci.json"):
     with filepath.open() as strm:
         for config in json.load(strm):
@@ -35,8 +35,8 @@ for filepath in dirpath.rglob("olive_ci.json"):
                     if key not in config:
                         config[key] = value
 
-                examples.append(config)
+                recipes.append(config)
 
-matrix = {"include": examples}
+matrix = {"include": recipes}
 output = json.dumps(matrix)
 print(output)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: main
-description: "CI workflow for Olive Examples"
+description: "CI workflow for Olive Recipes"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -59,7 +59,7 @@ jobs:
         matrix=$(python .github/scripts/generate_matrix.py . windows cuda)
         echo "windows_cuda_matrix=$matrix" >> $GITHUB_OUTPUT
 
-  ubuntu-cpu-examples:
+  ubuntu-cpu-recipes:
     needs: generate-matrix
     strategy:
       fail-fast: false
@@ -83,7 +83,7 @@ jobs:
       working-directory: ${{ github.workspace }}/${{ matrix.cwd }}
       run: ${{ matrix.command }}
 
-  ubuntu-cuda-examples:
+  ubuntu-cuda-recipes:
     needs: generate-matrix
     strategy:
       fail-fast: false
@@ -107,7 +107,7 @@ jobs:
       working-directory: ${{ github.workspace }}/${{ matrix.cwd }}
       run: ${{ matrix.command }}
 
-  windows-cpu-examples:
+  windows-cpu-recipes:
     needs: generate-matrix
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
     <img alt="olive" src="images/olive-black-text.png" height="100" style="max-width: 100%;">
   </picture>
 
-## Olive Examples For AI Model Optimization Toolkit Using ONNX Runtime
+## Olive Recipes For AI Model Optimization Toolkit Using ONNX Runtime
 </div>
 
-This repository compliments [Olive](https://github.com/microsoft/Olive), the AI model optimization toolkit, and includes examples demonstrating its extensive features and use cases. Users of Olive can use these examples as a reference to either optimize publicly available AI models or to optimize their own proprietary models.
+This repository compliments [Olive](https://github.com/microsoft/Olive), the AI model optimization toolkit, and includes recipes demonstrating its extensive features and use cases. Users of Olive can use these recipes as a reference to either optimize publicly available AI models or to optimize their own proprietary models.
 
 ## Learn more
 - [Olive Github Repository](https://github.com/microsoft/Olive)

--- a/bert/README.md
+++ b/bert/README.md
@@ -1,5 +1,5 @@
 # BERT Optimization
-This folder contains examples of BERT optimization using different workflows.
+This folder contains recipe for BERT optimization using different workflows.
 
 - QDQ: [Int8 Quantization with QDQ format](#bert-quantization-qdq)
 - CPU: [Optimization with PTQ for model from HF/AML](#bert-optimization-with-ptq-on-cpu)


### PR DESCRIPTION
## Update to use "Recipes" instead of "Examples"

Removing use of keyword "examples" in files and instead using "recipes". This is to better inline with the intent for the use of this repository.