### PR TITLE
Create a branch instead of pushing to main

### DIFF
--- a/.github/workflows/scanner.yml
+++ b/.github/workflows/scanner.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.10"
+  GHA_PR_BRANCH: "gha/update-$${{ github.run_id }}"
 
 jobs:
   scan:
@@ -47,11 +48,12 @@ jobs:
           echo "::set-output name=has_changes::false"
         fi
 
-    - name: Commit and push changes
+    - name: Create a new branch for the PR
       if: steps.check_changes.outputs.has_changes == 'true'
       run: |
         git config --global user.name "${{ github.actor }}"
         git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+        git checkout -b "${{ env.GHA_PR_BRANCH }}"
         git add README.md
-        git commit -m "Update README.md"
-        git push
+        git commit -m "[Scanner]: Ran scanner and update README.md"
+        git push origin "${{ env.GHA_PR_BRANCH }}"


### PR DESCRIPTION
## Create a branch instead of pushing to main

Pushing to main is a dead-end with permissions problems at every step. Same is true for creating a PR also.

Falling back to a safer, more reliable way. Create a branch with updated README and let the rest be a manual flow.