### PR TITLE
Conditionally disable Olive specific workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,11 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '*'     # Exclude files in root directory from triggering a build
+    paths:
+      - '**/olive_ci.json'  # Run this workflow only when Olive CI files are modified
   pull_request:
+    paths:
+      - '**/olive_ci.json'  # Run this workflow only when Olive CI files are modified
 
 env:
   PYTHON_VERSION: "3.10"


### PR DESCRIPTION
## Conditionally disable Olive specific workflows

Don't run (and block) non-Olive dev team contributions from merging when there's no change to olive CI files.