### PR TITLE
Add NvTensorRtRtx Olive recipes for phi3-mini-128k, Deepseek-Qwen-7B, and Qwen2.5-Coder-1.5B-Instruct models

### DIFF
--- a/Qwen-Qwen2.5-Coder-1.5B-Instruct/NvTensorRtRtx/Qwen2.5-Coder-1.5B-Instruct_model_builder_fp16.json
+++ b/Qwen-Qwen2.5-Coder-1.5B-Instruct/NvTensorRtRtx/Qwen2.5-Coder-1.5B-Instruct_model_builder_fp16.json
@@ -1,0 +1,18 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
+        "task": "text-classification"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [ { "device": "gpu", "execution_providers": [ "NvTensorRTRTXExecutionProvider" ] } ]
+        }
+    },
+    "engine": { "target": "local_system" },
+    "passes": {
+        "builder": { "type": "ModelBuilder", "precision": "fp16", "enable_cuda_graph": true }
+
+    }
+}

--- a/Qwen-Qwen2.5-Coder-1.5B-Instruct/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen2.5-Coder-1.5B-Instruct/NvTensorRtRtx/README.md
@@ -1,0 +1,21 @@
+# Qwen2.5-Coder-1.5B-Instruct optimization
+
+This folder contains examples of Olive recipes for `Qwen2.5-Coder-1.5B-Instruct` optimization.
+
+## FP16 Model Building
+
+The olive recipe `Qwen2.5-Coder-1.5B-Instruct_model_builder_fp16.json` uses `ModelBuilder` pass to generate the FP16 model for `NvTensorRTRTXExecutionProvider` (aka `NvTensorRtRtx` EP).
+
+### Setup
+
+1. Install Olive 
+
+2. Install onnxruntime-genai package that has support for NvTensorRTRTXExecutionProvider.
+
+### Steps to run
+
+Use the following command to export the model using Olive with NvTensorRTRTXExecutionProvider:
+
+```bash
+olive run --config Qwen2.5-Coder-1.5B-Instruct_model_builder_fp16.json
+```

--- a/Qwen-Qwen2.5-Coder-1.5B-Instruct/NvTensorRtRtx/info.yml
+++ b/Qwen-Qwen2.5-Coder-1.5B-Instruct/NvTensorRtRtx/info.yml
@@ -1,0 +1,6 @@
+arch: qwen2
+recipes:
+  - name: Qwen2.5-Coder-1.5B-Instruct_Model_Builder_FP16
+    file: Qwen2.5-Coder-1.5B-Instruct_model_builder_fp16.json
+    devices: gpu
+    eps: NvTensorRTRTXExecutionProvider

--- a/deepseek-ai-DeepSeek-R1-Distill-Qwen-7B/NvTensorRtRtx/DeepSeek-R1-Distill-Qwen-7B_nvmo_int4_rtn.json
+++ b/deepseek-ai-DeepSeek-R1-Distill-Qwen-7B/NvTensorRtRtx/DeepSeek-R1-Distill-Qwen-7B_nvmo_int4_rtn.json
@@ -1,0 +1,28 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+        "task": "text-classification"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [ { "device": "gpu", "execution_providers": [ "NvTensorRTRTXExecutionProvider" ] } ]
+        }
+    },
+    "engine": { "target": "local_system" },
+    "passes": {
+        "builder": { "type": "ModelBuilder", "precision": "fp16", "enable_cuda_graph": true},
+        "quantization": {
+            "type": "NVModelOptQuantization",
+            "algorithm": "rtn",
+            "tokenizer_dir": "deepseek-ai/DeepSeek-R1-Distill-Qwen-7B",
+            "int4_block_size": 32,
+            "calibration_method": "rtn_dq",
+            "calibration_params": {
+                 "add_position_ids": false
+            }
+        }
+    },
+    "log_severity_level": 0
+}

--- a/deepseek-ai-DeepSeek-R1-Distill-Qwen-7B/NvTensorRtRtx/README.md
+++ b/deepseek-ai-DeepSeek-R1-Distill-Qwen-7B/NvTensorRtRtx/README.md
@@ -1,10 +1,10 @@
-# DeepSeek-R1-Distill-Qwen-14B optimization
+# DeepSeek-R1-Distill-Qwen-7B optimization
 
-This folder contains examples of Olive recipes for `DeepSeek-R1-Distill-Qwen-14B` optimization.
+This folder contains examples of Olive recipes for `DeepSeek-R1-Distill-Qwen-7B` optimization.
 
-## INT4 AWQ Quantized Model Generation
+## INT4 RTN Quantized Model Generation
 
-The olive recipe `DeepSeek-R1-Distill-Qwen-14B_nvmo_int4_awq.json` produces INT4 AWQ quantized model using NVIDIA's TensorRT Model Optimizer toolkit.
+The olive recipe `DeepSeek-R1-Distill-Qwen-7B_nvmo_int4_rtn.json` produces INT4 RTN quantized model using NVIDIA's TensorRT Model Optimizer toolkit.
 
 ### Setup
 
@@ -42,20 +42,18 @@ The olive recipe `DeepSeek-R1-Distill-Qwen-14B_nvmo_int4_awq.json` produces INT4
 
     - Install packages provided in requirements text file.
     ```bash
-    pip install -r requirements-nvmo-awq.txt
+    pip install -r requirements-nvmo.txt
     ```
 
 ### Steps to run
 
 ```bash
-olive run --config DeepSeek-R1-Distill-Qwen-14B_nvmo_int4_awq.json
+olive run --config DeepSeek-R1-Distill-Qwen-7B_nvmo_int4_rtn.json
 ```
 
 ### Recipe details
 
-The olive recipe `DeepSeek-R1-Distill-Qwen-14B_nvmo_int4_awq.json` has 2 passes: (a) `ModelBuilder` and (b) `NVModelOptQuantization`. The `ModelBuilder` pass is used to generate the FP16 model for `NvTensorRTRTXExecutionProvider` (aka `NvTensorRtRtx` EP). Subsequently, the `NVModelOptQuantization` pass performs INT4 AWQ quantization to produce the 4-bit optimized model. In the quantization pass, execution-providers from the available/installed onnxruntime execution-providers is used for calibration. The field `calibration_providers` can be used to select any specific execution provider for calibration (assuming it is available/installed).
-
-- Note that while using NvTensorRTRTXExecutionProvider for INT4 AWQ quantization, profile (min/max/opt ranges) of shapes of the model-inputs is created internally using the details from the model's config (e.g. config.json in HuggingFace model card). This input-shapes-profile is used during onnxruntime session creation. Make sure that config.json is available in the model-directory if `tokenizer_dir` is a model path (instead of model-name).
+The olive recipe `DeepSeek-R1-Distill-Qwen-7B_nvmo_int4_rtn.json` has 2 passes: (a) `ModelBuilder` and (b) `NVModelOptQuantization`. The `ModelBuilder` pass is used to generate the FP16 model for `NvTensorRTRTXExecutionProvider` (aka `NvTensorRtRtx` EP). Subsequently, the `NVModelOptQuantization` pass performs INT4 RTN quantization to produce the 4-bit optimized model.
 
 ### Troubleshoot
 

--- a/deepseek-ai-DeepSeek-R1-Distill-Qwen-7B/NvTensorRtRtx/info.yml
+++ b/deepseek-ai-DeepSeek-R1-Distill-Qwen-7B/NvTensorRtRtx/info.yml
@@ -1,0 +1,6 @@
+arch: qwen2
+recipes:
+  - name: DeepSeek-R1-Distill-Qwen-7B_NVMO_INT4_RTN
+    file: DeepSeek-R1-Distill-Qwen-7B_nvmo_int4_rtn.json
+    devices: gpu
+    eps: NvTensorRTRTXExecutionProvider

--- a/deepseek-ai-DeepSeek-R1-Distill-Qwen-7B/NvTensorRtRtx/requirements-nvmo.txt
+++ b/deepseek-ai-DeepSeek-R1-Distill-Qwen-7B/NvTensorRtRtx/requirements-nvmo.txt
@@ -1,0 +1,3 @@
+datasets>=2.14.4
+torch
+transformers

--- a/microsoft-Phi-3-mini-128k-instruct/NvTensorRtRtx/Phi-3-mini-128k-instruct_nvmo_int4_rtn.json
+++ b/microsoft-Phi-3-mini-128k-instruct/NvTensorRtRtx/Phi-3-mini-128k-instruct_nvmo_int4_rtn.json
@@ -1,0 +1,28 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "microsoft/Phi-3-mini-128k-instruct",
+        "task": "text-classification"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [ { "device": "gpu", "execution_providers": [ "NvTensorRTRTXExecutionProvider" ] } ]
+        }
+    },
+    "engine": { "target": "local_system" },
+    "passes": {
+        "builder": { "type": "ModelBuilder", "precision": "fp16", "enable_cuda_graph": true},
+        "quantization": {
+            "type": "NVModelOptQuantization",
+            "algorithm": "rtn",
+            "int4_block_size": 32,
+            "tokenizer_dir": "microsoft/Phi-3-mini-128k-instruct",
+            "calibration_method": "rtn_dq",
+            "calibration_params": {
+                 "add_position_ids": false
+            }
+        }
+    },
+    "log_severity_level": 0
+}

--- a/microsoft-Phi-3-mini-128k-instruct/NvTensorRtRtx/README.md
+++ b/microsoft-Phi-3-mini-128k-instruct/NvTensorRtRtx/README.md
@@ -1,10 +1,10 @@
-# DeepSeek-R1-Distill-Qwen-14B optimization
+# Phi-3-mini-128k-instruct optimization
 
-This folder contains examples of Olive recipes for `DeepSeek-R1-Distill-Qwen-14B` optimization.
+This folder contains examples of Olive recipes for `Phi-3-mini-128k-instruct` optimization.
 
-## INT4 AWQ Quantized Model Generation
+## INT4 RTN Quantized Model Generation
 
-The olive recipe `DeepSeek-R1-Distill-Qwen-14B_nvmo_int4_awq.json` produces INT4 AWQ quantized model using NVIDIA's TensorRT Model Optimizer toolkit.
+The olive recipe `Phi-3-mini-128k-instruct_nvmo_int4_rtn.json` produces INT4 RTN quantized model using NVIDIA's TensorRT Model Optimizer toolkit.
 
 ### Setup
 
@@ -42,20 +42,18 @@ The olive recipe `DeepSeek-R1-Distill-Qwen-14B_nvmo_int4_awq.json` produces INT4
 
     - Install packages provided in requirements text file.
     ```bash
-    pip install -r requirements-nvmo-awq.txt
+    pip install -r requirements-nvmo.txt
     ```
 
 ### Steps to run
 
 ```bash
-olive run --config DeepSeek-R1-Distill-Qwen-14B_nvmo_int4_awq.json
+olive run --config Phi-3-mini-128k-instruct_nvmo_int4_rtn.json
 ```
 
 ### Recipe details
 
-The olive recipe `DeepSeek-R1-Distill-Qwen-14B_nvmo_int4_awq.json` has 2 passes: (a) `ModelBuilder` and (b) `NVModelOptQuantization`. The `ModelBuilder` pass is used to generate the FP16 model for `NvTensorRTRTXExecutionProvider` (aka `NvTensorRtRtx` EP). Subsequently, the `NVModelOptQuantization` pass performs INT4 AWQ quantization to produce the 4-bit optimized model. In the quantization pass, execution-providers from the available/installed onnxruntime execution-providers is used for calibration. The field `calibration_providers` can be used to select any specific execution provider for calibration (assuming it is available/installed).
-
-- Note that while using NvTensorRTRTXExecutionProvider for INT4 AWQ quantization, profile (min/max/opt ranges) of shapes of the model-inputs is created internally using the details from the model's config (e.g. config.json in HuggingFace model card). This input-shapes-profile is used during onnxruntime session creation. Make sure that config.json is available in the model-directory if `tokenizer_dir` is a model path (instead of model-name).
+The olive recipe `Phi-3-mini-128k-instruct_nvmo_int4_rtn.json` has 2 passes: (a) `ModelBuilder` and (b) `NVModelOptQuantization`. The `ModelBuilder` pass is used to generate the FP16 model for `NvTensorRTRTXExecutionProvider` (aka `NvTensorRtRtx` EP). Subsequently, the `NVModelOptQuantization` pass performs INT4 RTN quantization to produce the 4-bit optimized model.
 
 ### Troubleshoot
 

--- a/microsoft-Phi-3-mini-128k-instruct/NvTensorRtRtx/info.yml
+++ b/microsoft-Phi-3-mini-128k-instruct/NvTensorRtRtx/info.yml
@@ -1,0 +1,6 @@
+arch: phi3
+recipes:
+  - name: Phi-3-mini-128k-instruct_NVMO_INT4_RTN
+    file: Phi-3-mini-128k-instruct_nvmo_int4_rtn.json
+    devices: gpu
+    eps: NvTensorRTRTXExecutionProvider

--- a/microsoft-Phi-3-mini-128k-instruct/NvTensorRtRtx/requirements-nvmo.txt
+++ b/microsoft-Phi-3-mini-128k-instruct/NvTensorRtRtx/requirements-nvmo.txt
@@ -1,0 +1,3 @@
+datasets>=2.14.4
+torch
+transformers


### PR DESCRIPTION
Add NvTensorRtRtx Olive recipes for the following models:

- phi3-mini-128k-instruct
- DeepSeek-R1-Distill-Qwen-7B
- Qwen2.5-Coder-1.5B-Instruct 