### PR TITLE
QNN: Pin AOT ort-qnn version to 1.22.2

### DIFF
--- a/Qwen-Qwen2.5-1.5B-Instruct/QNN/README.md
+++ b/Qwen-Qwen2.5-1.5B-Instruct/QNN/README.md
@@ -32,7 +32,7 @@ pip install olive-ai==0.9.2
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
-pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
+pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn==1.22.2" --no-deps
 ```
 
 Replace `/path/to/qnn/env/bin` in [config.json](config.json) with the path to the directory containing your QNN environment's Python executable. This path can be found by running the following command in the environment:

--- a/Qwen-Qwen2.5-1.5B-Instruct/QNN/requirements.txt
+++ b/Qwen-Qwen2.5-1.5B-Instruct/QNN/requirements.txt
@@ -5,4 +5,4 @@ onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1
 optimum
 # newer transformers might have incompatibility with gptq passes
-transformers==4.52.4
+transformers==4.53.2

--- a/Qwen-Qwen2.5-7B-Instruct/QNN/README.md
+++ b/Qwen-Qwen2.5-7B-Instruct/QNN/README.md
@@ -32,7 +32,7 @@ pip install olive-ai==0.9.2
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
-pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
+pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn==1.22.2" --no-deps
 ```
 
 Replace `/path/to/qnn/env/bin` in [config.json](config.json) with the path to the directory containing your QNN environment's Python executable. This path can be found by running the following command in the environment:

--- a/Qwen-Qwen2.5-7B-Instruct/QNN/requirements.txt
+++ b/Qwen-Qwen2.5-7B-Instruct/QNN/requirements.txt
@@ -5,4 +5,4 @@ onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1
 optimum
 # newer transformers might have incompatibility with gptq passes
-transformers==4.52.4
+transformers==4.53.2

--- a/meta-llama-Llama-3.1-8B-Instruct/QNN/README.md
+++ b/meta-llama-Llama-3.1-8B-Instruct/QNN/README.md
@@ -32,7 +32,7 @@ pip install olive-ai==0.9.2
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
-pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
+pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn==1.22.2" --no-deps
 ```
 
 Replace `/path/to/qnn/env/bin` in [config.json](config.json) with the path to the directory containing your QNN environment's Python executable. This path can be found by running the following command in the environment:

--- a/meta-llama-Llama-3.1-8B-Instruct/QNN/requirements.txt
+++ b/meta-llama-Llama-3.1-8B-Instruct/QNN/requirements.txt
@@ -5,4 +5,4 @@ onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1
 optimum
 # newer transformers might have incompatibility with gptq passes
-transformers==4.52.4
+transformers==4.53.2

--- a/microsoft-Phi-3-mini-128k-instruct/QNN/README.md
+++ b/microsoft-Phi-3-mini-128k-instruct/QNN/README.md
@@ -32,7 +32,7 @@ pip install olive-ai==0.9.2
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
-pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
+pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn==1.22.2" --no-deps
 ```
 
 Replace `/path/to/qnn/env/bin` in [config.json](config.json) with the path to the directory containing your QNN environment's Python executable. This path can be found by running the following command in the environment:

--- a/microsoft-Phi-3-mini-128k-instruct/QNN/requirements.txt
+++ b/microsoft-Phi-3-mini-128k-instruct/QNN/requirements.txt
@@ -5,4 +5,4 @@ onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1
 optimum
 # newer transformers might have incompatibility with gptq passes
-transformers==4.52.4
+transformers==4.53.2

--- a/microsoft-Phi-3-mini-4k-instruct/QNN/README.md
+++ b/microsoft-Phi-3-mini-4k-instruct/QNN/README.md
@@ -32,7 +32,7 @@ pip install olive-ai==0.9.2
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
-pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
+pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn==1.22.2" --no-deps
 ```
 
 Replace `/path/to/qnn/env/bin` in [config.json](config.json) with the path to the directory containing your QNN environment's Python executable. This path can be found by running the following command in the environment:

--- a/microsoft-Phi-3-mini-4k-instruct/QNN/requirements.txt
+++ b/microsoft-Phi-3-mini-4k-instruct/QNN/requirements.txt
@@ -5,4 +5,4 @@ onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1
 optimum
 # newer transformers might have incompatibility with gptq passes
-transformers==4.52.4
+transformers==4.53.2

--- a/microsoft-Phi-3.5-mini-instruct/QNN/README.md
+++ b/microsoft-Phi-3.5-mini-instruct/QNN/README.md
@@ -32,7 +32,7 @@ pip install olive-ai==0.9.2
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt
-pip install -U --pre --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
+pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn==1.22.2" --no-deps
 ```
 
 Replace `/path/to/qnn/env/bin` in [config.json](config.json) with the path to the directory containing your QNN environment's Python executable. This path can be found by running the following command in the environment:

--- a/microsoft-Phi-3.5-mini-instruct/QNN/requirements.txt
+++ b/microsoft-Phi-3.5-mini-instruct/QNN/requirements.txt
@@ -5,4 +5,4 @@ onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1
 optimum
 # newer transformers might have incompatibility with gptq passes
-transformers==4.52.4
+transformers==4.53.2


### PR DESCRIPTION
- Use a stable version of onnxruntime-qnn for context binary generation. the QNN SDK version on latest nightly keeps getting updated. Don't want to compile a model that cannot run with stable releases of winml or ort-qnn