### PR TITLE
QNN: Update to 0.9.3, use CalibStridedMinMax

### DIFF
--- a/Qwen-Qwen2.5-1.5B-Instruct/QNN/README.md
+++ b/Qwen-Qwen2.5-1.5B-Instruct/QNN/README.md
@@ -28,7 +28,7 @@ Model compilation using QNN Execution Provider requires a Python environment wit
 
 ```bash
 # Install Olive
-pip install olive-ai==0.9.2
+pip install olive-ai==0.9.3
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt

--- a/Qwen-Qwen2.5-1.5B-Instruct/QNN/config.json
+++ b/Qwen-Qwen2.5-1.5B-Instruct/QNN/config.json
@@ -74,7 +74,8 @@
             "calibration_providers": [ "CUDAExecutionProvider" ],
             "quant_preprocess": true,
             "op_types_to_exclude": [ "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
-            "save_as_external_data": true
+            "save_as_external_data": true,
+            "extra_option": { "CalibStridedMinMax": 4 }
         },
         "sp": { "type": "SplitModel" },
         "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },

--- a/Qwen-Qwen2.5-1.5B-Instruct/QNN/requirements.txt
+++ b/Qwen-Qwen2.5-1.5B-Instruct/QNN/requirements.txt
@@ -1,5 +1,5 @@
 datasets
-olive-ai==0.9.2
+olive-ai==0.9.3
 # these are the versions the recipes were last validated with
 onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1

--- a/Qwen-Qwen2.5-7B-Instruct/QNN/README.md
+++ b/Qwen-Qwen2.5-7B-Instruct/QNN/README.md
@@ -28,7 +28,7 @@ Model compilation using QNN Execution Provider requires a Python environment wit
 
 ```bash
 # Install Olive
-pip install olive-ai==0.9.2
+pip install olive-ai==0.9.3
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt

--- a/Qwen-Qwen2.5-7B-Instruct/QNN/config.json
+++ b/Qwen-Qwen2.5-7B-Instruct/QNN/config.json
@@ -74,7 +74,8 @@
             "calibration_providers": [ "CUDAExecutionProvider" ],
             "quant_preprocess": true,
             "op_types_to_exclude": [ "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
-            "save_as_external_data": true
+            "save_as_external_data": true,
+            "extra_option": { "CalibStridedMinMax": 4 }
         },
         "sp": { "type": "SplitModel" },
         "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },

--- a/Qwen-Qwen2.5-7B-Instruct/QNN/requirements.txt
+++ b/Qwen-Qwen2.5-7B-Instruct/QNN/requirements.txt
@@ -1,5 +1,5 @@
 datasets
-olive-ai==0.9.2
+olive-ai==0.9.3
 # these are the versions the recipes were last validated with
 onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1

--- a/meta-llama-Llama-3.1-8B-Instruct/QNN/README.md
+++ b/meta-llama-Llama-3.1-8B-Instruct/QNN/README.md
@@ -28,7 +28,7 @@ Model compilation using QNN Execution Provider requires a Python environment wit
 
 ```bash
 # Install Olive
-pip install olive-ai==0.9.2
+pip install olive-ai==0.9.3
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt

--- a/meta-llama-Llama-3.1-8B-Instruct/QNN/config.json
+++ b/meta-llama-Llama-3.1-8B-Instruct/QNN/config.json
@@ -74,7 +74,8 @@
             "calibration_providers": [ "CUDAExecutionProvider" ],
             "quant_preprocess": true,
             "op_types_to_exclude": [ "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
-            "save_as_external_data": true
+            "save_as_external_data": true,
+            "extra_option": { "CalibStridedMinMax": 4 }
         },
         "sp": { "type": "SplitModel" },
         "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },

--- a/meta-llama-Llama-3.1-8B-Instruct/QNN/requirements.txt
+++ b/meta-llama-Llama-3.1-8B-Instruct/QNN/requirements.txt
@@ -1,5 +1,5 @@
 datasets
-olive-ai==0.9.2
+olive-ai==0.9.3
 # these are the versions the recipes were last validated with
 onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1

--- a/microsoft-Phi-3-mini-128k-instruct/QNN/README.md
+++ b/microsoft-Phi-3-mini-128k-instruct/QNN/README.md
@@ -28,7 +28,7 @@ Model compilation using QNN Execution Provider requires a Python environment wit
 
 ```bash
 # Install Olive
-pip install olive-ai==0.9.2
+pip install olive-ai==0.9.3
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt

--- a/microsoft-Phi-3-mini-128k-instruct/QNN/config.json
+++ b/microsoft-Phi-3-mini-128k-instruct/QNN/config.json
@@ -74,7 +74,8 @@
             "calibration_providers": [ "CUDAExecutionProvider" ],
             "quant_preprocess": true,
             "op_types_to_exclude": [ "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
-            "save_as_external_data": true
+            "save_as_external_data": true,
+            "extra_option": { "CalibStridedMinMax": 4 }
         },
         "sp": { "type": "SplitModel" },
         "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },

--- a/microsoft-Phi-3-mini-128k-instruct/QNN/requirements.txt
+++ b/microsoft-Phi-3-mini-128k-instruct/QNN/requirements.txt
@@ -1,5 +1,5 @@
 datasets
-olive-ai==0.9.2
+olive-ai==0.9.3
 # these are the versions the recipes were last validated with
 onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1

--- a/microsoft-Phi-3-mini-4k-instruct/QNN/README.md
+++ b/microsoft-Phi-3-mini-4k-instruct/QNN/README.md
@@ -28,7 +28,7 @@ Model compilation using QNN Execution Provider requires a Python environment wit
 
 ```bash
 # Install Olive
-pip install olive-ai==0.9.2
+pip install olive-ai==0.9.3
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt

--- a/microsoft-Phi-3-mini-4k-instruct/QNN/config.json
+++ b/microsoft-Phi-3-mini-4k-instruct/QNN/config.json
@@ -74,7 +74,8 @@
             "calibration_providers": [ "CUDAExecutionProvider" ],
             "quant_preprocess": true,
             "op_types_to_exclude": [ "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
-            "save_as_external_data": true
+            "save_as_external_data": true,
+            "extra_option": { "CalibStridedMinMax": 4 }
         },
         "sp": { "type": "SplitModel" },
         "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },

--- a/microsoft-Phi-3-mini-4k-instruct/QNN/requirements.txt
+++ b/microsoft-Phi-3-mini-4k-instruct/QNN/requirements.txt
@@ -1,5 +1,5 @@
 datasets
-olive-ai==0.9.2
+olive-ai==0.9.3
 # these are the versions the recipes were last validated with
 onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1

--- a/microsoft-Phi-3.5-mini-instruct/QNN/README.md
+++ b/microsoft-Phi-3.5-mini-instruct/QNN/README.md
@@ -28,7 +28,7 @@ Model compilation using QNN Execution Provider requires a Python environment wit
 
 ```bash
 # Install Olive
-pip install olive-ai==0.9.2
+pip install olive-ai==0.9.3
 
 # Install ONNX Runtime QNN
 pip install -r https://raw.githubusercontent.com/microsoft/onnxruntime/refs/heads/main/requirements.txt

--- a/microsoft-Phi-3.5-mini-instruct/QNN/config.json
+++ b/microsoft-Phi-3.5-mini-instruct/QNN/config.json
@@ -72,7 +72,8 @@
             "calibration_providers": [ "CUDAExecutionProvider" ],
             "quant_preprocess": true,
             "op_types_to_exclude": [ "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
-            "save_as_external_data": true
+            "save_as_external_data": true,
+            "extra_option": { "CalibStridedMinMax": 4 }
         },
         "sp": { "type": "SplitModel" },
         "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },

--- a/microsoft-Phi-3.5-mini-instruct/QNN/config_fp16.json
+++ b/microsoft-Phi-3.5-mini-instruct/QNN/config_fp16.json
@@ -78,7 +78,8 @@
             "calibration_providers": [ "CUDAExecutionProvider" ],
             "quant_preprocess": true,
             "op_types_to_exclude": [ "Cast", "GatherBlockQuantized", "GroupQueryAttention", "MatMulNBits" ],
-            "save_as_external_data": true
+            "save_as_external_data": true,
+            "extra_option": { "CalibStridedMinMax": 4 }
         },
         "sp": { "type": "SplitModel" },
         "st": { "type": "StaticLLM", "batch_size": 1, "context_length": 64 },

--- a/microsoft-Phi-3.5-mini-instruct/QNN/requirements.txt
+++ b/microsoft-Phi-3.5-mini-instruct/QNN/requirements.txt
@@ -1,5 +1,5 @@
 datasets
-olive-ai==0.9.2
+olive-ai==0.9.3
 # these are the versions the recipes were last validated with
 onnxruntime-genai-cuda==0.7.1
 onnxruntime-gpu==1.21.1


### PR DESCRIPTION
- Update to 0.9.3 so that we can use strided calibration data for lower RAM usage.