### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: main
 description: "CI workflow for Olive Recipes"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/olive-recipes/security/code-scanning/5](https://github.com/microsoft/olive-recipes/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/main.yml` so all jobs default to least privilege.  
Best single fix without changing behavior is:

- Add at workflow root (near `name`/`description`/`concurrency`):  
  `permissions:`  
  `  contents: read`

This satisfies checkout and matrix-generation use cases shown, constrains `GITHUB_TOKEN`, and avoids changing job logic. If any hidden/truncated job later needs write scopes, that specific job should get a targeted per-job `permissions` override.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
