### PR TITLE
Fix checkpoint weight loading for Qwen2.5-VL vision and embedding models

### DIFF
--- a/Qwen-Qwen2.5-VL-3B-Instruct/builtin/codes/modeling_qwen2_5_vl.py
+++ b/Qwen-Qwen2.5-VL-3B-Instruct/builtin/codes/modeling_qwen2_5_vl.py
@@ -1039,8 +1039,11 @@ class Qwen2_5_VLTextModel(Qwen2_5_VLPreTrainedModel):
 
 @auto_docstring
 class Qwen2_5_VLModel(Qwen2_5_VLPreTrainedModel):
-    base_model_prefix = ""
-    _checkpoint_conversion_mapping = {"^model": "language_model"}
+    base_model_prefix = "model"
+    _checkpoint_conversion_mapping = {
+        "^model.visual": "visual",
+        "^model.language_model": "language_model",
+    }
     # Reference: fix gemma3 grad acc #37208
     accepts_loss_kwargs = False
     config: Qwen2_5_VLConfig

--- a/Qwen-Qwen2.5-VL-3B-Instruct/builtin/codes/modeling_qwen2_5_vl.py
+++ b/Qwen-Qwen2.5-VL-3B-Instruct/builtin/codes/modeling_qwen2_5_vl.py
@@ -1040,10 +1040,7 @@ class Qwen2_5_VLTextModel(Qwen2_5_VLPreTrainedModel):
 @auto_docstring
 class Qwen2_5_VLModel(Qwen2_5_VLPreTrainedModel):
     base_model_prefix = "model"
-    _checkpoint_conversion_mapping = {
-        r"^model\.visual": "visual",
-        r"^model\.language_model": "language_model",
-    }
+    _checkpoint_conversion_mapping = {}
     # Reference: fix gemma3 grad acc #37208
     accepts_loss_kwargs = False
     config: Qwen2_5_VLConfig

--- a/Qwen-Qwen2.5-VL-3B-Instruct/builtin/codes/modeling_qwen2_5_vl.py
+++ b/Qwen-Qwen2.5-VL-3B-Instruct/builtin/codes/modeling_qwen2_5_vl.py
@@ -1041,8 +1041,8 @@ class Qwen2_5_VLTextModel(Qwen2_5_VLPreTrainedModel):
 class Qwen2_5_VLModel(Qwen2_5_VLPreTrainedModel):
     base_model_prefix = "model"
     _checkpoint_conversion_mapping = {
-        "^model.visual": "visual",
-        "^model.language_model": "language_model",
+        r"^model\.visual": "visual",
+        r"^model\.language_model": "language_model",
     }
     # Reference: fix gemma3 grad acc #37208
     accepts_loss_kwargs = False


### PR DESCRIPTION
# Fix checkpoint weight loading for Qwen2.5-VL vision and embedding models

## Problem

The `Qwen2_5_VLModel` class had an incorrect `_checkpoint_conversion_mapping` that caused all pretrained weights to load under wrong parameter keys. This resulted in the vision and embedding models being initialized with random weights, producing gibberish output during multimodal inference.

## Root Cause

The original mapping `{"^model": "language_model"}` incorrectly transformed checkpoint keys:

| Checkpoint key | After old mapping | Expected key |
|---|---|---|
| `model.visual.*` | `language_model.visual.*` ❌ | `visual.*` |
| `model.language_model.*` | `language_model.language_model.*` ❌ | `language_model.*` |

Since no weights matched the expected keys, all parameters were randomly initialized. The ONNX-exported vision and embedding models contained garbage weights, while the text model (exported via ModelBuilder, which loads weights independently) was unaffected.

## Fix

Updated `_checkpoint_conversion_mapping` to correctly map each prefix:

```python
# Before
base_model_prefix = ""
_checkpoint_conversion_mapping = {"^model": "language_model"}

# After
base_model_prefix = "model"
_checkpoint_conversion_mapping = {
    "^model.visual": "visual",
    "^model.language_model": "language_model",
}