### PR TITLE
Add Gemma 4 E2B QNN (Snapdragon Hexagon NPU) recipe — WIP

### DIFF
--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -4,10 +4,80 @@
 > running [`google/gemma-4-E2B-it`](https://huggingface.co/google/gemma-4-E2B-it)
 > on the Qualcomm Hexagon NPU via the QNN ONNX Runtime execution
 > provider (Snapdragon X / Copilot+ PC, Snapdragon 8 Gen 3+, etc.).
-> Has *not* yet been validated on hardware — see
-> [Limitations](#limitations).
+> The HTP EPContext compilation has *not* yet been validated on hardware
+> — see [Limitations](#limitations).
 
-## Approach
+## Two build paths
+
+This directory ships **two** ways to produce the INT4 Gemma 4 E2B ONNX
+model that the QNN AOT stages then compile to an HTP context binary:
+
+| Path | Config | INT4 source | Cost |
+|---|---|---|---|
+| **GGUF-direct (recommended)** | `config_gguf.json` | reuse [`unsloth/gemma-4-E2B-it-GGUF`](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF) Q4_K_M weights | cheap — no calibration/RTN quant |
+| HF-source | `config.json` | quantize fp32 weights with `OnnxKQuantQuantization` | expensive (RTN over 262 k-vocab; GPU / cupy recommended) |
+
+The **GGUF-direct** path is the reason to use the unsloth GGUF: it skips
+the expensive `OnnxKQuantQuantization` pass entirely by re-packing the
+already-INT4 GGUF weights into `com.microsoft::MatMulNBits`, then runs
+the identical QNN AOT stages. `mobius build-gguf` performs the GGUF →
+ONNX conversion; the resulting model has been **verified end-to-end** to
+produce correct text on ONNX Runtime CPU (see below).
+
+### GGUF-direct: step 1 — build the INT4 ONNX with mobius
+
+Run this once, on any machine (x64 or Windows ARM64), in the quantization
+environment:
+
+```bash
+pip install "mobius-ai[gguf]"
+mobius build-gguf "unsloth/gemma-4-E2B-it-GGUF:gemma-4-E2B-it-Q4_K_M.gguf" \
+    --keep-quantized --ep qnn --dtype f16 --output model_int4
+```
+
+This emits `model_int4/model.onnx` — the Gemma 4 E2B text decoder with
+INT4 `MatMulNBits` projections (205 nodes), opset-24 standard `Attention`
+(35, no GroupQueryAttention — the QNN capability advertises empty
+`gqa_dtypes`), and `RMSNormalization`. Mixed Q6_K tensors in the Q4_K_M
+preset are re-quantized to 4-bit / block-32 automatically.
+
+> **Requires the mobius Gemma-4 GGUF fixes**
+> ([onnxruntime/mobius PR](https://github.com/onnxruntime/mobius/pull/new/justinchuby/gemma4-gguf-qnn)):
+> per-layer `feed_forward_length` → scalar + `use_double_wide_mlp`,
+> per-layer-input tensor mapping, quantized-linear wiring, KV-shared
+> standard-Attention shape inference, and the `gelu_pytorch_tanh`
+> activation default (Gemma GGUFs omit the activation key; the old `silu`
+> default produced garbage output). Without these, the build either fails
+> to load in ORT or generates incoherent text.
+
+Verified on Windows ARM64 (Snapdragon), ONNX Runtime 1.27 CPU EP, from
+`model_int4/model.onnx`:
+
+```
+Q: What is the capital of France?   A: The capital of France is **Paris**.
+Q: Name a primary color.            A: Red
+```
+
+The dequantized GGUF weights were confirmed to match the gated
+`google/gemma-4-E2B-it` safetensors checkpoint (all projection / norm /
+embedding correlations ≥ 0.98).
+
+### GGUF-direct: step 2 — compile to a QNN HTP context binary
+
+Point `config_gguf.json`'s `input_model.model_path` at the
+`model_int4/model.onnx` produced above (and set the `qnn_system` Python
+path), then run Olive from the quantization environment:
+
+```bash
+olive run --config config_gguf.json
+```
+
+`config_gguf.json` drops `MobiusBuilder` **and** `OnnxKQuantQuantization`
+(the INT4 weights already exist) and runs only
+`MatMulNBitsToQDQ → OnnxStaticQuantization → StaticLLM →
+EPContextBinaryGenerator`.
+
+## Approach (HF-source path)
 
 All four Gemma 4 components (decoder, embedding, vision_encoder,
 audio_encoder) are compiled into QNN EPContext binaries together.

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -204,25 +204,45 @@ This recipe has **not yet been validated end-to-end**. Concrete findings
 from HTP experiments on a Snapdragon X (ORT 1.27, onnxruntime-qnn 2.4.0,
 QNN SDK 2.48.40, HTP V73):
 
-0. **gemma4 `--static-cache` is the top prerequisite.** HTP needs fully
-   static shapes, and Olive's QNN `StaticLLM` needs the ORT-GenAI
-   static-KV contract. mobius `build-gguf --static-cache` now provides the
-   general plumbing, but the Gemma-4 decoder itself does not implement the
-   `StaticCacheState` dispatch — its `Gemma4TextAttention` has KV-shared
-   layers (some layers borrow K,V from a source layer and keep no cache of
-   their own), sliding-window + full alternating layers, and dual
-   local/global RoPE. Adding static-cache support means: (a) generating a
-   static-cache attention bias for *both* layer types via
-   `create_static_cache_attention_bias`, (b) threading `StaticCacheState`
-   through `Gemma4DecoderLayer` / `Gemma4TextAttention`, allocating buffers
-   only for the `num_kv_layers` cache layers, (c) making KV-shared layers
-   read the source layer's static buffer. This is correctness-critical
-   surgery on the most complex model in mobius and must be validated with
-   HF numerical parity before use.
+0. **gemma4 `--static-cache` — DONE** (onnxruntime/mobius, commit `5d804b7`).
+   `Gemma4TextAttention`/`Gemma4DecoderLayer` now implement the
+   `StaticCacheState` dispatch: static-cache attention bias for both sliding
+   and full layer types, per-cache-layer buffers (KV-shared layers borrow the
+   source layer's static buffer, so only the `num_kv_layers` cache-owning
+   layers get buffers), and dual head_dim (sliding vs full). Verified: static
+   decode logits match the dynamic reference at every position (~1e-6 fp32),
+   and the full E2B static model **generates correct text on ORT CPU**
+   (`build-gguf ... --static-cache --max-seq-len 512` → "The capital of France
+   is **Paris**."). `build-gguf --static-cache` emits a fully static-shaped,
+   decomposed, QDQ graph (0 fused `Attention`, 0 `MatMulNBits`, 30
+   `TensorScatter`, 15 cache layers with dual head_dim 256/512).
 
-1. **Full-model single-graph HTP compose fails on size.** See the blocker
-   note under [step 2](#gguf-direct-step-2--compile-to-a-qnn-htp-context-binary).
-   Needs model splitting + weight-shared EPContext binaries.
+1. **Full-model single-graph HTP still needs splitting — two confirmed
+   blockers** (Snapdragon X, ORT 1.27, onnxruntime-qnn 2.4.0):
+   - **4.7 GB per-layer embedding overflows QNN's 32-bit static-tensor
+     size** (`embed_tokens_per_layer` `[262144, 8960]` fp16 = 4 697 620 480 B
+     wraps mod 2³² → 402 653 184 B → `Data length mismatch for static
+     tensor`). Fix: keep the embedding tables on CPU. Splitting the graph
+     after the two embedding `Gather`s yields a 5.5 GB embedding model (CPU)
+     and a 2.15 GB transformer (no > 4 GB tensors) — the transformer then
+     *composes* on HTP.
+   - **The 35-layer transformer fails single-graph HTP finalization**
+     (`Failed to finalize QNN graph` after ~20 min) — one context is too
+     large. A **4-layer chunk composes on HTP in ~21 s and runs**, so the fix
+     is to split the transformer into weight-shared EPContext chunks
+     (`SplitModel` / `EPContextBinaryGenerator(weight_sharing=True)`).
+
+2. **Performance: mobius's decompose+inline QDQ form runs slowly on HTP.**
+   The 4-layer chunk decodes at ~650–810 ms/step (extrapolates to ~0.2 tok/s
+   for 35 layers) because the decomposed SDPA + `DequantizeLinear`+`MatMul`
+   land largely on the CPU EP (QNN partitions them out) with HTP↔CPU
+   transfers, and the runtime INT4 nibble-unpack (`BitwiseAnd`/`BitShift`,
+   constant-foldable) adds overhead. A *reasonable* NPU throughput needs the
+   Olive static-INT path: **keep `MatMulNBits`** in the mobius export and run
+   `MatMulNBitsToQDQ` (clean int4 initializers, no runtime unpack) +
+   `OnnxStaticQuantization` (uint16 activations / uint8 weights) so the matmuls
+   hit HTP's integer engine, then chunk into weight-shared EPContext binaries.
+   This is now unblocked by the static-cache support above.
 
 2. **Fused ops have no HTP kernel** (filed as
    [onnxruntime/onnxruntime-qnn#646](https://github.com/onnxruntime/onnxruntime-qnn/issues/646)):

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -354,6 +354,28 @@ The resulting model loads on the QNN HTP with
 real deployment, replace `FakeCalib` with a proper calibration dataset (the
 `static_quant` pass in `config_gguf.json`) so the output is accurate.
 
+### GPU (Adreno) vs NPU (HTP) backend
+
+The QNN EP can also target the Adreno **GPU** (`backend_path=QnnGpu.dll`)
+instead of the Hexagon **NPU** (`backend_path=QnnHtp.dll`). All the tok/s
+numbers above use the **HTP (NPU)** backend. For reference, a 10-layer E2B-dim
+feed-forward stack (hidden 1536 / intermediate 6144, batch=1 decode shape,
+best-of-3 on a Snapdragon X) placed on each backend:
+
+| Model | CPU EP | QNN GPU (Adreno) | QNN HTP (NPU) |
+|---|---|---|---|
+| int8 per-channel QDQ | 2.75 ms | 3.03 ms | 2.92 ms |
+| fp16 | 11.18 ms | 10.51 ms | **9.38 ms** |
+
+Both QNN backends genuinely engage (on fp16 the GPU beats the CPU EP), but the
+**HTP (NPU) is the fastest in every case**; the GPU sits between CPU and NPU.
+For int8 the ARM64 CPU EP is already very strong (good dot-product SIMD), so the
+NPU's edge is small — consistent with the batch-1 decode being memory-bound. The
+GPU backend is a valid fallback where the HTP is unavailable or oversubscribed,
+but it is **not** faster than the NPU for this workload. (Note: `QnnCpu.dll` is
+not shipped in the `onnxruntime-qnn` wheel — only `QnnGpu.dll` and `QnnHtp.dll`.)
+
+
 ## Discussion
 
 If you have a Snapdragon test rig and the pipeline blows up on a

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -1,56 +1,51 @@
 # Gemma 4 E2B QNN (Snapdragon Hexagon NPU) recipe
 
-> **Status: WORK IN PROGRESS / EXPLORATORY.** This recipe is a starting
-> point for running [`google/gemma-4-E2B-it`](https://huggingface.co/google/gemma-4-E2B-it)
+> **Status: WORK IN PROGRESS / EXPLORATORY.** Starting-point recipe for
+> running [`google/gemma-4-E2B-it`](https://huggingface.co/google/gemma-4-E2B-it)
 > on the Qualcomm Hexagon NPU via the QNN ONNX Runtime execution
 > provider (Snapdragon X / Copilot+ PC, Snapdragon 8 Gen 3+, etc.).
-> It has *not* yet been end-to-end validated on hardware — see the
-> [Limitations](#limitations) section below before using it in
-> production.
+> Has *not* yet been validated on hardware — see
+> [Limitations](#limitations).
 
-This recipe targets the **text decoder only**. Gemma 4's vision and
-audio encoders run on CPU (`google-gemma-4-E2B-it/cpu/`) or GPU
-(`google-gemma-4-E2B-it/cuda/`); only the LM decoder is compiled into
-an EPContext binary for HTP execution.
+## Approach
 
-## Pipeline overview
+All four Gemma 4 components (decoder, embedding, vision_encoder,
+audio_encoder) are compiled into QNN EPContext binaries together.
+Olive's per-component dispatch on `CompositeModelHandler` runs each
+pass on every component, then `EPContextBinaryGenerator` and
+`ComposeOnnxModels` (both `_accepts_composite_model = True`) finalize
+the multimodal package.
+
+## Pipeline
 
 ```
-HfModel (multimodal Gemma4)
-   ↓ MobiusBuilder fp32       → ORT GenAI multi-component package
-   ↓ OnnxKQuantQuantization   → INT4 weights (decoder only)
-   ↓ MatMulNBitsToQDQ         → QDQ format for static quantization
-   ↓ GraphSurgeries           → QNN-friendly graph (Rope unmerge, mask, L2Norm)
-   ↓ OnnxStaticQuantization   → activations uint16 / weights uint8 (calibrated)
-   ↓ SplitModel + StaticLLM   → static-shape sub-graphs for QNN
-   ↓ EPContextBinaryGenerator → compiled HTP EPContext blob
+HfModel (multimodal Gemma 4)
+   ↓ MobiusBuilder (fp32)               4 ONNX components + genai_config + tokenizer + processors
+   ↓ OnnxKQuantQuantization (INT4)      mobius-standard Q4_K_M quant (per component)
+   ↓ OnnxStaticQuantization             activations uint16 / weights uint8 (calibrated)
+   ↓ StaticLLM                          static shapes for QNN
+   ↓ EPContextBinaryGenerator           HTP EPContext blobs (per component, weight-shared)
+   ↓ ComposeOnnxModels                  final package
 ```
 
 ## Prerequisites
 
-### Quantization environment (x64 with CUDA GPU)
-Quantization (especially `OnnxStaticQuantization`) is resource-intensive
-and accelerated by GPU:
-
+### Quantization environment (x64, GPU recommended)
 ```bash
 pip install -r requirements.txt
+pip install cupy-cuda12x   # accelerates OnnxKQuantQuantization (19–51× speedup)
 ```
 
 ### AOT compilation environment (separate venv, x64 with QNN SDK)
-Compilation into the EPContext binary requires
-`onnxruntime-qnn`:
-
 ```bash
 pip install olive-ai mobius-ai
 pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn" --no-deps
 ```
 
-Set `/path/to/qnn/env/bin` in `config.json` to the directory containing
-your QNN venv's Python executable.
+Replace `/path/to/qnn/env/bin` in `config.json` with the directory
+containing your QNN venv's Python executable.
 
-### Inference environment (Snapdragon device)
-On Copilot+ PC / Snapdragon X / Android (Snapdragon 8 Gen 3+):
-
+### Inference (Snapdragon device)
 ```bash
 pip install onnxruntime-qnn onnxruntime-genai
 ```
@@ -61,52 +56,55 @@ pip install onnxruntime-qnn onnxruntime-genai
 olive run --config config.json
 ```
 
-Output is a self-contained EPContext binary package suitable for QNN HTP
-execution.
+## Why no `GraphSurgeries` here?
+
+Most existing QNN recipes (Phi-3, Qwen) chain surgeries like
+`RemoveRopeMultiCache`, `AttentionMaskToSequenceLengths`,
+`SimplifiedLayerNormToL2Norm`. Those rewrite ModelBuilder-specific
+sub-graphs into shapes HTP can lower:
+
+| Surgery | What it does | Why ModelBuilder needs it |
+|---|---|---|
+| `SimplifiedLayerNormToL2Norm` | `com.microsoft.SimplifiedLayerNorm` → `LpNormalization * gamma` | HTP has no SimplifiedLayerNorm kernel |
+| `RemoveRopeMultiCache` | Drop one of ModelBuilder's two RoPE caches | HTP can't dispatch on cache selector |
+| `AttentionMaskToSequenceLengths` | `GQA(attention_mask=[B,T])` → `GQA(past_seq_len, total_seq_len)` | HTP's GQA kernel wants scalar seq lens |
+
+`MobiusBuilder` emits opset-23 standard ops (`RMSNormalization`,
+`Attention`) instead of the contrib variants, so these surgeries are
+either no-ops or inapplicable. Gemma-4–specific surgeries may still be
+needed (e.g. lowering the final logit soft-cap `cap * tanh(x / cap)`),
+but the existing borrowed-from-Phi-3 set is not it.
 
 ## Limitations
 
 This recipe has **not yet been validated end-to-end**. Known gaps:
 
-1. **Multimodal `google/gemma-4-E2B-it` always produces a 4-component
-   package** (decoder + embedding + vision + audio). MobiusBuilder
-   currently does not expose a `model_type` / `module_class` override
-   to force the text-only `gemma4_text` build, so the pipeline must
-   either: (a) run the QNN passes only on the `decoder` component and
-   leave the others as fp32, or (b) wait for the upstream MobiusBuilder
-   to gain a `module_class` parameter. This recipe assumes (a) but the
-   QNN pass chain currently expects a single ONNX model — the
-   integration is still TODO.
+1. **Logit soft-cap may not lower to HTP.** Gemma 4's
+   `logits = cap * tanh(logits / cap)` is unusual for QNN. If HTP
+   rejects it, options are (a) skip soft-cap during QNN compile and
+   apply it in host post-processing, or (b) add a
+   `RemoveLogitSoftcap` GraphSurgery upstream in Olive.
 
-2. **Gemma 4's exotic ops may break QNN GraphSurgeries.** The recipe
-   borrows surgeries (`RemoveRopeMultiCache`, `AttentionMaskToSequenceLengths`,
-   `SimplifiedLayerNormToL2Norm`) from Phi-3 / Qwen QNN recipes; they
-   have not been verified against Gemma 4's hybrid local/global
-   attention, `tie_word_embeddings`, dual head_dim KV cache, or final
-   logit soft-capping (`logits = cap * tanh(logits / cap)`). The
-   soft-cap subgraph in particular may not lower cleanly to HTP — may
-   need to be folded into the logit lookup or skipped during QNN
-   compilation.
+2. **Hybrid local/global attention with dual head_dim.** Gemma 4 E2B
+   alternates local sliding-window (head_dim=256) and global
+   (head_dim=512) attention layers. Whether HTP can dispatch this
+   correctly per-layer needs testing.
 
-3. **Per-layer-input embeddings.** Gemma 4 E2B emits a second embedding
-   output (`per_layer_inputs`, shape `[B, S, L*D]`) consumed by every
-   decoder block. The split between embedding-on-CPU and decoder-on-HTP
-   needs a custom orchestrator (or both sub-models compiled into QNN
-   together).
+3. **`per_layer_inputs` data flow.** The embedding component emits a
+   second output (`per_layer_inputs`, shape `[B, S, L*D]`) consumed by
+   every decoder block. When all components compile to QNN this should
+   "just work" (the data path stays inside the package), but the
+   `StaticLLM` pass may need a hint to recognise this extra tensor.
 
-4. **Calibration data shape.** `OnnxStaticQuantization` calibration uses
-   `wikitext-2`; for Gemma 4 (which has a 256k tokenizer including
-   image / audio special tokens) the calibration set may under-represent
-   tokens that actually appear at inference time. Consider augmenting
-   with multimodal-formatted prompts.
+4. **256k tokenizer calibration.** `wikitext-2` calibration likely
+   under-represents Gemma 4's image / audio special tokens. Consider
+   augmenting with multimodal-formatted prompts before production.
 
-5. **`StaticLLM context_length=64`.** Mirrors Phi-3 / Qwen QNN recipes
-   but is unlikely to be useful for a real Gemma 4 deployment; tune to
-   target Snapdragon SKU memory budget once HW validation is possible.
+5. **`StaticLLM context_length=64`.** Placeholder mirroring existing QNN
+   recipes; tune to target Snapdragon SKU memory budget.
 
 ## Discussion
 
-If you have a Snapdragon test rig and run into specific failures,
-please add a comment with the trace; this recipe is intended as a
-template that other contributors can iterate on rather than a
-production-ready pipeline.
+If you have a Snapdragon test rig and the pipeline blows up on a
+specific pass, please drop the trace in a comment — this recipe is
+intentionally a template for iteration, not a finished product.

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -1,0 +1,112 @@
+# Gemma 4 E2B QNN (Snapdragon Hexagon NPU) recipe
+
+> **Status: WORK IN PROGRESS / EXPLORATORY.** This recipe is a starting
+> point for running [`google/gemma-4-E2B-it`](https://huggingface.co/google/gemma-4-E2B-it)
+> on the Qualcomm Hexagon NPU via the QNN ONNX Runtime execution
+> provider (Snapdragon X / Copilot+ PC, Snapdragon 8 Gen 3+, etc.).
+> It has *not* yet been end-to-end validated on hardware — see the
+> [Limitations](#limitations) section below before using it in
+> production.
+
+This recipe targets the **text decoder only**. Gemma 4's vision and
+audio encoders run on CPU (`google-gemma-4-E2B-it/cpu/`) or GPU
+(`google-gemma-4-E2B-it/cuda/`); only the LM decoder is compiled into
+an EPContext binary for HTP execution.
+
+## Pipeline overview
+
+```
+HfModel (multimodal Gemma4)
+   ↓ MobiusBuilder fp32       → ORT GenAI multi-component package
+   ↓ OnnxKQuantQuantization   → INT4 weights (decoder only)
+   ↓ MatMulNBitsToQDQ         → QDQ format for static quantization
+   ↓ GraphSurgeries           → QNN-friendly graph (Rope unmerge, mask, L2Norm)
+   ↓ OnnxStaticQuantization   → activations uint16 / weights uint8 (calibrated)
+   ↓ SplitModel + StaticLLM   → static-shape sub-graphs for QNN
+   ↓ EPContextBinaryGenerator → compiled HTP EPContext blob
+```
+
+## Prerequisites
+
+### Quantization environment (x64 with CUDA GPU)
+Quantization (especially `OnnxStaticQuantization`) is resource-intensive
+and accelerated by GPU:
+
+```bash
+pip install -r requirements.txt
+```
+
+### AOT compilation environment (separate venv, x64 with QNN SDK)
+Compilation into the EPContext binary requires
+`onnxruntime-qnn`:
+
+```bash
+pip install olive-ai mobius-ai
+pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn" --no-deps
+```
+
+Set `/path/to/qnn/env/bin` in `config.json` to the directory containing
+your QNN venv's Python executable.
+
+### Inference environment (Snapdragon device)
+On Copilot+ PC / Snapdragon X / Android (Snapdragon 8 Gen 3+):
+
+```bash
+pip install onnxruntime-qnn onnxruntime-genai
+```
+
+## Build
+
+```bash
+olive run --config config.json
+```
+
+Output is a self-contained EPContext binary package suitable for QNN HTP
+execution.
+
+## Limitations
+
+This recipe has **not yet been validated end-to-end**. Known gaps:
+
+1. **Multimodal `google/gemma-4-E2B-it` always produces a 4-component
+   package** (decoder + embedding + vision + audio). MobiusBuilder
+   currently does not expose a `model_type` / `module_class` override
+   to force the text-only `gemma4_text` build, so the pipeline must
+   either: (a) run the QNN passes only on the `decoder` component and
+   leave the others as fp32, or (b) wait for the upstream MobiusBuilder
+   to gain a `module_class` parameter. This recipe assumes (a) but the
+   QNN pass chain currently expects a single ONNX model — the
+   integration is still TODO.
+
+2. **Gemma 4's exotic ops may break QNN GraphSurgeries.** The recipe
+   borrows surgeries (`RemoveRopeMultiCache`, `AttentionMaskToSequenceLengths`,
+   `SimplifiedLayerNormToL2Norm`) from Phi-3 / Qwen QNN recipes; they
+   have not been verified against Gemma 4's hybrid local/global
+   attention, `tie_word_embeddings`, dual head_dim KV cache, or final
+   logit soft-capping (`logits = cap * tanh(logits / cap)`). The
+   soft-cap subgraph in particular may not lower cleanly to HTP — may
+   need to be folded into the logit lookup or skipped during QNN
+   compilation.
+
+3. **Per-layer-input embeddings.** Gemma 4 E2B emits a second embedding
+   output (`per_layer_inputs`, shape `[B, S, L*D]`) consumed by every
+   decoder block. The split between embedding-on-CPU and decoder-on-HTP
+   needs a custom orchestrator (or both sub-models compiled into QNN
+   together).
+
+4. **Calibration data shape.** `OnnxStaticQuantization` calibration uses
+   `wikitext-2`; for Gemma 4 (which has a 256k tokenizer including
+   image / audio special tokens) the calibration set may under-represent
+   tokens that actually appear at inference time. Consider augmenting
+   with multimodal-formatted prompts.
+
+5. **`StaticLLM context_length=64`.** Mirrors Phi-3 / Qwen QNN recipes
+   but is unlikely to be useful for a real Gemma 4 deployment; tune to
+   target Snapdragon SKU memory budget once HW validation is possible.
+
+## Discussion
+
+If you have a Snapdragon test rig and run into specific failures,
+please add a comment with the trace; this recipe is intended as a
+template that other contributors can iterate on rather than a
+production-ready pipeline.

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -244,7 +244,7 @@ QNN SDK 2.48.40, HTP V73):
    hit HTP's integer engine, then chunk into weight-shared EPContext binaries.
    This is now unblocked by the static-cache support above.
 
-2. **HTP op coverage — DONE in the mobius qnn lowering** (onnxruntime/mobius
+3. **HTP op coverage — DONE in the mobius qnn lowering** (onnxruntime/mobius
    commit `be98116`). Empirically (Snapdragon X, onnxruntime-qnn 2.4.0,
    `session.disable_cpu_ep_fallback=1`) the QNN HTP backend has **no kernel**
    for these ops, each forcing its node onto CPU: the fused opset-24
@@ -262,7 +262,7 @@ QNN SDK 2.48.40, HTP V73):
    Filed the original fused-op gap as
    [onnxruntime/onnxruntime-qnn#646](https://github.com/onnxruntime/onnxruntime-qnn/issues/646).
 
-2b. **INT4 weights still need quantized *activations* for HTP.** A weight-only
+4. **INT4 weights still need quantized *activations* for HTP.** A weight-only
    `DequantizeLinear`→`MatMul` (float activations) runs on HTP **only** for
    *per-tensor* weights; *per-channel* and *blocked* int8/int4 weight DQ is
    CPU-forced. QNN HTP claims per-channel/blocked weight matmuls only inside a
@@ -274,22 +274,22 @@ QNN SDK 2.48.40, HTP V73):
    qnn lowering (4× larger, so still needs the transformer chunked for HTP
    finalization); (b) INT4 + Olive static activation quant → int8 QDQ on HTP.
 
-3. **Logit soft-cap may not lower to HTP.** Gemma 4's
+5. **Logit soft-cap may not lower to HTP.** Gemma 4's
    `logits = cap * tanh(logits / cap)` is unusual for QNN. If HTP
    rejects it, options are (a) skip soft-cap during QNN compile and
    apply it in host post-processing, or (b) add a
    `RemoveLogitSoftcap` GraphSurgery upstream in Olive.
 
-4. **Hybrid local/global attention with dual head_dim.** Gemma 4 E2B
+6. **Hybrid local/global attention with dual head_dim.** Gemma 4 E2B
    alternates local sliding-window and global attention layers with
    different head_dim. Small dual-head_dim subsets compose on HTP; the
    full alternation at 35 layers is untested past the size blocker above.
 
-5. **256k tokenizer calibration.** `wikitext-2` calibration likely
+7. **256k tokenizer calibration.** `wikitext-2` calibration likely
    under-represents Gemma 4's image / audio special tokens. Consider
    augmenting with multimodal-formatted prompts before production.
 
-6. **`StaticLLM context_length=64`.** Placeholder mirroring existing QNN
+8. **`StaticLLM context_length=64`.** Placeholder mirroring existing QNN
    recipes; tune to the target Snapdragon SKU memory budget.
 
 ### Reference: tok/s baselines (gemma-4-E2B Q4_K_M, Snapdragon X, 12 threads)

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -300,7 +300,59 @@ QNN SDK 2.48.40, HTP V73):
 | mobius INT4 ONNX (ORT CPU EP) | 18.2 |
 | HuggingFace transformers (fp32 torch CPU) | 0.04 |
 
-These are the CPU baselines to beat once the HTP/NPU path is unblocked.
+## Measured HTP results (fully-on-HTP path)
+
+With the mobius qnn lowering (commit `be98116`) **every op runs on HTP** — no
+CPU fallback — once the INT4 GGUF weights are re-quantized to a QNN-runnable
+form. Measured on a Snapdragon X (onnxruntime-qnn 2.4.0), 10-layer model at
+E2B per-layer dims (hidden 1536, intermediate 6144, head_dim 256/512,
+static cache max_seq_len=512), extrapolated to the 35-layer transformer
+(embeddings + lm_head excluded, run on CPU):
+
+| Quantization | **HTP (NPU)** decode | **CPU** decode |
+|---|---|---|
+| int4 per-channel + uint8 activations | **16.4 tok/s** | 17.5 tok/s |
+| int8 per-channel + uint8 activations | 16.6 tok/s | 16.7 tok/s |
+
+**The NPU decode speed ≈ CPU (~16–17 tok/s); it does not beat CPU here, and
+int4 vs int8 barely differ.** Single-token (batch=1) decode is memory-bound and
+low-parallelism — not the regime an NPU wins. IO-binding (in-place KV) and
+EPContext were tried and did **not** change decode latency (CPU/HTP share SoC
+DRAM, so there is no host↔device transfer to eliminate; EPContext only speeds up
+model *loading*). The HTP's real value is **power efficiency, prefill throughput,
+and batching**, not single-stream decode tok/s.
+
+**How to get a fully-on-HTP model (fake-calibration shortcut for testing).**
+QNN HTP claims a weight `DequantizeLinear`→`MatMul` only for **per-channel**
+int4/int8 weights inside a **full int QDQ group** (quantized activations); the
+GGUF Q4_K **blocked** form (`block_size=32`) is CPU-forced at any bit width
+(see [onnxruntime/onnxruntime-qnn#650](https://github.com/onnxruntime/onnxruntime-qnn/issues/650)).
+So the INT4 blocked weights must be re-quantized to **per-channel** and the
+activations quantized. For a throughput/latency test where accuracy does not
+matter, run `onnxruntime.quantization.quantize_static` with a **fake
+calibration reader** (a couple of random/zero input batches) instead of the
+expensive wikitext calibration — it inserts per-channel weight QDQ + uint8
+activation QDQ and completes in seconds:
+
+```python
+from onnxruntime.quantization import (
+    quantize_static, QuantType, QuantFormat, CalibrationDataReader)
+
+class FakeCalib(CalibrationDataReader):
+    def __init__(self, feeds): self.it = iter(feeds)          # a few dummy input dicts
+    def get_next(self): return next(self.it, None)
+
+quantize_static(
+    "model_static.onnx", "model_int8.onnx", FakeCalib(dummy_feeds),
+    quant_format=QuantFormat.QDQ, per_channel=True,
+    activation_type=QuantType.QUInt8, weight_type=QuantType.QInt4,  # or QInt8
+    op_types_to_quantize=["MatMul"])
+```
+
+The resulting model loads on the QNN HTP with
+`session.disable_cpu_ep_fallback = "1"` and runs entirely on the NPU. For a
+real deployment, replace `FakeCalib` with a proper calibration dataset (the
+`static_quant` pass in `config_gguf.json`) so the output is accurate.
 
 ## Discussion
 

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -48,8 +48,8 @@ pip install cupy-cuda12x   # accelerates OnnxKQuantQuantization (19–51× speed
 
 ### AOT compilation environment (separate venv, x64 with QNN SDK)
 ```bash
-pip install olive-ai mobius-ai
-pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn" --no-deps
+pip install olive-ai==0.9.3 mobius-ai
+pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn==1.22.2" --no-deps
 ```
 
 Replace `/path/to/qnn/env/bin` in `config.json` with the directory
@@ -61,6 +61,11 @@ pip install onnxruntime-qnn onnxruntime-genai
 ```
 
 ## Build
+
+Run `olive run` from the **quantization environment** (not the QNN AOT
+venv). Olive invokes the QNN AOT venv automatically via the
+`python_environment_path` configured under `systems.qnn_system` for the
+`EPContextBinaryGenerator` pass:
 
 ```bash
 olive run --config config.json

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -48,8 +48,8 @@ pip install cupy-cuda12x   # accelerates OnnxKQuantQuantization (19–51× speed
 
 ### AOT compilation environment (separate venv, x64 with QNN SDK)
 ```bash
-pip install olive-ai==0.9.3 mobius-ai
-pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple "onnxruntime-qnn==1.22.2" --no-deps
+pip install olive-ai mobius-ai
+pip install --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple onnxruntime-qnn --no-deps
 ```
 
 Replace `/path/to/qnn/env/bin` in `config.json` with the directory

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -244,13 +244,35 @@ QNN SDK 2.48.40, HTP V73):
    hit HTP's integer engine, then chunk into weight-shared EPContext binaries.
    This is now unblocked by the static-cache support above.
 
-2. **Fused ops have no HTP kernel** (filed as
-   [onnxruntime/onnxruntime-qnn#646](https://github.com/onnxruntime/onnxruntime-qnn/issues/646)):
-   the opset-24 `Attention` op and `com.microsoft::MatMulNBits` are forced
-   onto CPU by the QNN EP. mobius `--ep qnn` decomposes / inlines both so
-   the graph stays on HTP; empirically `RMSNormalization`, `Gelu`,
-   `MatMul`, `Softmax`, `Transpose` and blocked `DequantizeLinear` *do*
-   run on HTP.
+2. **HTP op coverage — DONE in the mobius qnn lowering** (onnxruntime/mobius
+   commit `be98116`). Empirically (Snapdragon X, onnxruntime-qnn 2.4.0,
+   `session.disable_cpu_ep_fallback=1`) the QNN HTP backend has **no kernel**
+   for these ops, each forcing its node onto CPU: the fused opset-24
+   `Attention`, `com.microsoft::MatMulNBits`, `RotaryEmbedding`,
+   `TensorScatter`, `Tile`, `Range`, `BitwiseAnd`/`BitShift`. mobius `--ep qnn`
+   now lowers **all** of them to HTP-supported equivalents:
+   `Attention`→SDPA, `RotaryEmbedding`→rotate-half, `TensorScatter`→`ScatterND`,
+   `Tile`→`Expand`, `Range`→`Constant`+`Slice`, `MatMulNBits`→QDQ, and the
+   `BitwiseAnd`/`BitShift` nibble-unpack constant-folds away. HTP-OK primitives
+   confirmed: `MatMul`, `Softmax`, `RMSNormalization`, `Gelu`, `Sigmoid`,
+   `Transpose`, `Reshape`, `Slice`, `Concat`, `Expand`, `ScatterND`, `Where`,
+   `GreaterOrEqual`, `Less`, `And`, `Neg`, `Mul`, `Add`, `Sub`, `Div`,
+   `ReduceMean`, `Sqrt`, `Gather`. **Result: a non-quantized (fp16) gemma4
+   static model composes and runs *entirely* on the HTP** (no CPU fallback).
+   Filed the original fused-op gap as
+   [onnxruntime/onnxruntime-qnn#646](https://github.com/onnxruntime/onnxruntime-qnn/issues/646).
+
+2b. **INT4 weights still need quantized *activations* for HTP.** A weight-only
+   `DequantizeLinear`→`MatMul` (float activations) runs on HTP **only** for
+   *per-tensor* weights; *per-channel* and *blocked* int8/int4 weight DQ is
+   CPU-forced. QNN HTP claims per-channel/blocked weight matmuls only inside a
+   **full int QDQ group** — `DequantizeLinear(act)` + `DequantizeLinear(weight
+   per-channel)` → `MatMul` → `QuantizeLinear`. So the GGUF INT4 weights need
+   **quantized activations** (`OnnxStaticQuantization`, which needs calibration)
+   to keep their matmuls on HTP — that is an Olive pass, not a mobius lowering.
+   Two viable deployments: (a) fp16 weights → fully on HTP today via the mobius
+   qnn lowering (4× larger, so still needs the transformer chunked for HTP
+   finalization); (b) INT4 + Olive static activation quant → int8 QDQ on HTP.
 
 3. **Logit soft-cap may not lower to HTP.** Gemma 4's
    `logits = cap * tanh(logits / cap)` is unusual for QNN. If HTP

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -21,12 +21,22 @@ the multimodal package.
 ```
 HfModel (multimodal Gemma 4)
    ↓ MobiusBuilder (fp32)               4 ONNX components + genai_config + tokenizer + processors
-   ↓ OnnxKQuantQuantization (INT4)      mobius-standard Q4_K_M quant (per component)
+   ↓ OnnxKQuantQuantization (INT4)      mobius-standard Q4_K_M; weights → com.microsoft::MatMulNBits
+   ↓ MatMulNBitsToQDQ                   MatMulNBits → MatMul + DequantizeLinear (QNN-compatible QDQ)
    ↓ OnnxStaticQuantization             activations uint16 / weights uint8 (calibrated)
    ↓ StaticLLM                          static shapes for QNN
    ↓ EPContextBinaryGenerator           HTP EPContext blobs (per component, weight-shared)
    ↓ ComposeOnnxModels                  final package
 ```
+
+Why both `OnnxKQuantQuantization` and `MatMulNBitsToQDQ`?
+`OnnxKQuantQuantization` emits `com.microsoft::MatMulNBits`, which has
+fast CPU / CUDA kernels but is *not* in the QNN EP's supported-op list
+— without `MatMulNBitsToQDQ` the QNN partitioner rejects every
+quantized MatMul and the model silently falls back to CPU.
+`MatMulNBitsToQDQ` rewrites each `MatMulNBits` into a standard
+`MatMul + DequantizeLinear` pair so QNN can claim and compile the
+subgraph onto HTP.
 
 ## Prerequisites
 

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -35,11 +35,30 @@ mobius build-gguf "unsloth/gemma-4-E2B-it-GGUF:gemma-4-E2B-it-Q4_K_M.gguf" \
     --keep-quantized --ep qnn --dtype f16 --output model_int4
 ```
 
-This emits `model_int4/model.onnx` — the Gemma 4 E2B text decoder with
-INT4 `MatMulNBits` projections (205 nodes), opset-24 standard `Attention`
-(35, no GroupQueryAttention — the QNN capability advertises empty
-`gqa_dtypes`), and `RMSNormalization`. Mixed Q6_K tensors in the Q4_K_M
+This emits `model_int4/model.onnx` — the Gemma 4 E2B text decoder. With
+`--ep qnn` the mobius QNN capability now **decomposes** the fused opset-24
+`Attention` op into scaled-dot-product primitives (Reshape / Transpose /
+MatMul / Softmax / Add / Tile) and **inlines** `com.microsoft::MatMulNBits`
+into a QDQ form (nibble-unpack + blocked `DequantizeLinear` + `MatMul`),
+because the QNN HTP backend has no kernel for either fused op (they would
+otherwise be forced onto CPU — see
+[onnxruntime/onnxruntime-qnn#646](https://github.com/onnxruntime/onnxruntime-qnn/issues/646)).
+`RMSNormalization` is kept (HTP runs it). Mixed Q6_K tensors in the Q4_K_M
 preset are re-quantized to 4-bit / block-32 automatically.
+
+Because mobius already lowers `MatMulNBits` → QDQ for `--ep qnn`, the Olive
+`MatMulNBitsToQDQ` pass is a **no-op** on this model and is omitted from
+`config_gguf.json`.
+
+> **Static shapes for HTP.** The HTP backend requires *fully static*
+> shapes. mobius `build-gguf` now accepts `--static-cache --max-seq-len N`
+> (pre-allocated fixed-width KV buffers written in place via
+> `TensorScatter`) to emit a static-shaped graph. **Caveat:** the Gemma-4
+> decoder does not yet implement the `StaticCacheState` dispatch (it has
+> KV-shared / sliding-window layers with dual RoPE), so
+> `--static-cache` currently raises `TypeError` for gemma4. Adding that
+> support is the main prerequisite for the QNN AOT path below — see
+> [Limitations](#limitations).
 
 > **Requires the mobius Gemma-4 GGUF fixes**
 > ([onnxruntime/mobius PR](https://github.com/onnxruntime/mobius/pull/new/justinchuby/gemma4-gguf-qnn)):
@@ -72,10 +91,29 @@ path), then run Olive from the quantization environment:
 olive run --config config_gguf.json
 ```
 
-`config_gguf.json` drops `MobiusBuilder` **and** `OnnxKQuantQuantization`
-(the INT4 weights already exist) and runs only
-`MatMulNBitsToQDQ → OnnxStaticQuantization → StaticLLM →
-EPContextBinaryGenerator`.
+`config_gguf.json` drops `MobiusBuilder`, `OnnxKQuantQuantization`, **and**
+`MatMulNBitsToQDQ` (the mobius `--ep qnn` build already emits decomposed
+Attention + QDQ INT4 weights) and runs only
+`OnnxStaticQuantization → StaticLLM → EPContextBinaryGenerator`.
+
+> **Known blocker (this recipe is not yet hardware-validated).** Two
+> gaps remain before the AOT stages compile the full model to HTP:
+>
+> 1. **Full-model single-graph HTP compose fails on size.** The complete
+>    35-layer / 4.65 B-param E2B graph returns `EP_FAIL: Failed to
+>    compose Qnn graph`. Bisection shows small/medium subsets (up to a few
+>    full-width layers, 262 k vocab, dual head_dim) compose fine on HTP —
+>    it is the *total* single-context size that exceeds the HTP
+>    finalization budget. The fix is to split the model and compile
+>    weight-shared EPContext binaries (`StaticLLM` / `SplitModel` +
+>    `EPContextBinaryGenerator(weight_sharing=True)`).
+> 2. **`StaticLLM` expects the ORT-GenAI static-KV contract.** Olive's
+>    QNN `StaticLLM` path assumes a GQA model with `past_seq_len` /
+>    `total_seq_len` scalar inputs and a fixed sliding-window KV buffer.
+>    mobius's `--ep qnn` output uses standard decomposed attention with
+>    `attention_mask` / `position_ids` and dynamic concat-grow KV, so it
+>    does not match. Implementing gemma4 `--static-cache` (see
+>    [Limitations](#limitations)) is the prerequisite that closes this gap.
 
 ## Approach (HF-source path)
 
@@ -162,47 +200,65 @@ but the existing borrowed-from-Phi-3 set is not it.
 
 ## Limitations
 
-This recipe has **not yet been validated end-to-end**. Known gaps:
+This recipe has **not yet been validated end-to-end**. Concrete findings
+from HTP experiments on a Snapdragon X (ORT 1.27, onnxruntime-qnn 2.4.0,
+QNN SDK 2.48.40, HTP V73):
 
-1. **Logit soft-cap may not lower to HTP.** Gemma 4's
+0. **gemma4 `--static-cache` is the top prerequisite.** HTP needs fully
+   static shapes, and Olive's QNN `StaticLLM` needs the ORT-GenAI
+   static-KV contract. mobius `build-gguf --static-cache` now provides the
+   general plumbing, but the Gemma-4 decoder itself does not implement the
+   `StaticCacheState` dispatch — its `Gemma4TextAttention` has KV-shared
+   layers (some layers borrow K,V from a source layer and keep no cache of
+   their own), sliding-window + full alternating layers, and dual
+   local/global RoPE. Adding static-cache support means: (a) generating a
+   static-cache attention bias for *both* layer types via
+   `create_static_cache_attention_bias`, (b) threading `StaticCacheState`
+   through `Gemma4DecoderLayer` / `Gemma4TextAttention`, allocating buffers
+   only for the `num_kv_layers` cache layers, (c) making KV-shared layers
+   read the source layer's static buffer. This is correctness-critical
+   surgery on the most complex model in mobius and must be validated with
+   HF numerical parity before use.
+
+1. **Full-model single-graph HTP compose fails on size.** See the blocker
+   note under [step 2](#gguf-direct-step-2--compile-to-a-qnn-htp-context-binary).
+   Needs model splitting + weight-shared EPContext binaries.
+
+2. **Fused ops have no HTP kernel** (filed as
+   [onnxruntime/onnxruntime-qnn#646](https://github.com/onnxruntime/onnxruntime-qnn/issues/646)):
+   the opset-24 `Attention` op and `com.microsoft::MatMulNBits` are forced
+   onto CPU by the QNN EP. mobius `--ep qnn` decomposes / inlines both so
+   the graph stays on HTP; empirically `RMSNormalization`, `Gelu`,
+   `MatMul`, `Softmax`, `Transpose` and blocked `DequantizeLinear` *do*
+   run on HTP.
+
+3. **Logit soft-cap may not lower to HTP.** Gemma 4's
    `logits = cap * tanh(logits / cap)` is unusual for QNN. If HTP
    rejects it, options are (a) skip soft-cap during QNN compile and
    apply it in host post-processing, or (b) add a
    `RemoveLogitSoftcap` GraphSurgery upstream in Olive.
 
-2. **Hybrid local/global attention with dual head_dim.** Gemma 4 E2B
-   alternates local sliding-window (head_dim=256) and global
-   (head_dim=512) attention layers. Whether HTP can dispatch this
-   correctly per-layer needs testing.
+4. **Hybrid local/global attention with dual head_dim.** Gemma 4 E2B
+   alternates local sliding-window and global attention layers with
+   different head_dim. Small dual-head_dim subsets compose on HTP; the
+   full alternation at 35 layers is untested past the size blocker above.
 
-3. **`per_layer_inputs` data flow.** The embedding component emits a
-   second output (`per_layer_inputs`, shape `[B, S, L*D]`) consumed by
-   every decoder block. When all components compile to QNN this should
-   "just work" (the data path stays inside the package), but the
-   `StaticLLM` pass may need a hint to recognise this extra tensor.
-
-4. **256k tokenizer calibration.** `wikitext-2` calibration likely
+5. **256k tokenizer calibration.** `wikitext-2` calibration likely
    under-represents Gemma 4's image / audio special tokens. Consider
    augmenting with multimodal-formatted prompts before production.
 
-5. **`StaticLLM context_length=64`.** Placeholder mirroring existing QNN
-   recipes; tune to target Snapdragon SKU memory budget.
+6. **`StaticLLM context_length=64`.** Placeholder mirroring existing QNN
+   recipes; tune to the target Snapdragon SKU memory budget.
 
-6. **Standard `Attention` op, not `GroupQueryAttention`.** mobius only
-   emits `com.microsoft::GroupQueryAttention(seqlens_k, total_seq_len)`
-   when the EP capability advertises `gqa_dtypes`. The QNN EP
-   capability in mobius currently has an empty `gqa_dtypes` list, so
-   `Gemma4TextModel.forward` (`src/mobius/models/gemma4.py:1500-1508`)
-   falls back to the standard opset-23 `Attention` with an
-   `attention_mask` input. QNN's HTP backend should have an attention
-   kernel for the standard op, but if it doesn't lower well there are
-   two options:
-   - extend mobius `ep_capabilities()` to advertise QNN-supported
-     dtypes for `gqa_dtypes`, then mobius will emit `GQA` directly
-     (no GraphSurgery needed); or
-   - port `AttentionMaskToSequenceLengths` to operate on standard
-     `Attention` (it currently checks for `GroupQueryAttention` only
-     and no-ops otherwise).
+### Reference: tok/s baselines (gemma-4-E2B Q4_K_M, Snapdragon X, 12 threads)
+
+| Runtime | Decode tok/s |
+|---|---|
+| llama.cpp (CPU ARM64) | 43.7 |
+| mobius INT4 ONNX (ORT CPU EP) | 18.2 |
+| HuggingFace transformers (fp32 torch CPU) | 0.04 |
+
+These are the CPU baselines to beat once the HTP/NPU path is unblocked.
 
 ## Discussion
 

--- a/google-gemma-4-E2B-it/QNN/README.md
+++ b/google-gemma-4-E2B-it/QNN/README.md
@@ -113,6 +113,22 @@ This recipe has **not yet been validated end-to-end**. Known gaps:
 5. **`StaticLLM context_length=64`.** Placeholder mirroring existing QNN
    recipes; tune to target Snapdragon SKU memory budget.
 
+6. **Standard `Attention` op, not `GroupQueryAttention`.** mobius only
+   emits `com.microsoft::GroupQueryAttention(seqlens_k, total_seq_len)`
+   when the EP capability advertises `gqa_dtypes`. The QNN EP
+   capability in mobius currently has an empty `gqa_dtypes` list, so
+   `Gemma4TextModel.forward` (`src/mobius/models/gemma4.py:1500-1508`)
+   falls back to the standard opset-23 `Attention` with an
+   `attention_mask` input. QNN's HTP backend should have an attention
+   kernel for the standard op, but if it doesn't lower well there are
+   two options:
+   - extend mobius `ep_capabilities()` to advertise QNN-supported
+     dtypes for `gqa_dtypes`, then mobius will emit `GQA` directly
+     (no GraphSurgery needed); or
+   - port `AttentionMaskToSequenceLengths` to operate on standard
+     `Attention` (it currently checks for `GroupQueryAttention` only
+     and no-ops otherwise).
+
 ## Discussion
 
 If you have a Snapdragon test rig and the pipeline blows up on a

--- a/google-gemma-4-E2B-it/QNN/config.json
+++ b/google-gemma-4-E2B-it/QNN/config.json
@@ -1,0 +1,91 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "google/gemma-4-E2B-it" },
+    "systems": {
+        "qnn_system": {
+            "type": "PythonEnvironment",
+            "python_environment_path": "/path/to/qnn/env/bin",
+            "accelerators": [
+                { "device": "npu", "execution_providers": ["QNNExecutionProvider"] }
+            ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "wikitext2_train_act",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": {
+                "data_name": "wikitext",
+                "subset": "wikitext-2-raw-v1",
+                "split": "train"
+            },
+            "pre_process_data_config": {
+                "strategy": "line-by-line",
+                "add_special_tokens": true,
+                "max_samples": 256,
+                "max_seq_len": 1024
+            }
+        }
+    ],
+    "passes": {
+        "mobius_build": {
+            "type": "MobiusBuilder",
+            "precision": "fp32"
+        },
+        "matmul_nbits": {
+            "type": "OnnxKQuantQuantization",
+            "bits": 4,
+            "block_size": 32,
+            "save_as_external_data": true
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": true,
+            "save_as_external_data": true
+        },
+        "gs": {
+            "type": "GraphSurgeries",
+            "surgeries": [
+                { "surgeon": "RemoveRopeMultiCache" },
+                { "surgeon": "AttentionMaskToSequenceLengths" },
+                { "surgeon": "SimplifiedLayerNormToL2Norm" }
+            ],
+            "save_as_external_data": true
+        },
+        "sq": {
+            "type": "OnnxStaticQuantization",
+            "data_config": "wikitext2_train_act",
+            "activation_type": "uint16",
+            "precision": "uint8",
+            "calibration_providers": ["CUDAExecutionProvider"],
+            "quant_preprocess": true,
+            "op_types_to_exclude": [
+                "GatherBlockQuantized",
+                "GroupQueryAttention",
+                "MatMulNBits"
+            ],
+            "save_as_external_data": true
+        },
+        "sp": { "type": "SplitModel" },
+        "st": {
+            "type": "StaticLLM",
+            "batch_size": 1,
+            "context_length": 64
+        },
+        "cb": {
+            "type": "EPContextBinaryGenerator",
+            "provider_options": {
+                "htp_performance_mode": "burst",
+                "htp_graph_finalization_optimization_mode": "3",
+                "soc_model": "60"
+            },
+            "weight_sharing": true
+        },
+        "cp": { "type": "ComposeOnnxModels" }
+    },
+    "target": "qnn_system",
+    "output_dir": "model/gemma4_e2b_qnn",
+    "cache_dir": "cache",
+    "no_artifacts": true,
+    "evaluate_input_model": false
+}

--- a/google-gemma-4-E2B-it/QNN/config.json
+++ b/google-gemma-4-E2B-it/QNN/config.json
@@ -37,6 +37,12 @@
             "block_size": 32,
             "save_as_external_data": true
         },
+        "mnb_to_qdq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": true,
+            "save_as_external_data": true
+        },
         "static_quant": {
             "type": "OnnxStaticQuantization",
             "data_config": "wikitext2_train_act",

--- a/google-gemma-4-E2B-it/QNN/config.json
+++ b/google-gemma-4-E2B-it/QNN/config.json
@@ -31,28 +31,13 @@
             "type": "MobiusBuilder",
             "precision": "fp32"
         },
-        "matmul_nbits": {
+        "int4_quantize": {
             "type": "OnnxKQuantQuantization",
             "bits": 4,
             "block_size": 32,
             "save_as_external_data": true
         },
-        "mq": {
-            "type": "MatMulNBitsToQDQ",
-            "use_int4": true,
-            "add_zero_point": true,
-            "save_as_external_data": true
-        },
-        "gs": {
-            "type": "GraphSurgeries",
-            "surgeries": [
-                { "surgeon": "RemoveRopeMultiCache" },
-                { "surgeon": "AttentionMaskToSequenceLengths" },
-                { "surgeon": "SimplifiedLayerNormToL2Norm" }
-            ],
-            "save_as_external_data": true
-        },
-        "sq": {
+        "static_quant": {
             "type": "OnnxStaticQuantization",
             "data_config": "wikitext2_train_act",
             "activation_type": "uint16",
@@ -66,13 +51,12 @@
             ],
             "save_as_external_data": true
         },
-        "sp": { "type": "SplitModel" },
-        "st": {
+        "static_llm": {
             "type": "StaticLLM",
             "batch_size": 1,
             "context_length": 64
         },
-        "cb": {
+        "ep_context": {
             "type": "EPContextBinaryGenerator",
             "provider_options": {
                 "htp_performance_mode": "burst",
@@ -81,7 +65,7 @@
             },
             "weight_sharing": true
         },
-        "cp": { "type": "ComposeOnnxModels" }
+        "compose": { "type": "ComposeOnnxModels" }
     },
     "target": "qnn_system",
     "output_dir": "model/gemma4_e2b_qnn",

--- a/google-gemma-4-E2B-it/QNN/config_gguf.json
+++ b/google-gemma-4-E2B-it/QNN/config_gguf.json
@@ -1,0 +1,73 @@
+{
+    "input_model": {
+        "type": "ONNXModel",
+        "model_path": "model_int4/model.onnx"
+    },
+    "systems": {
+        "qnn_system": {
+            "type": "PythonEnvironment",
+            "python_environment_path": "/path/to/qnn/env/bin",
+            "accelerators": [
+                { "device": "npu", "execution_providers": ["QNNExecutionProvider"] }
+            ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "wikitext2_train_act",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": {
+                "data_name": "wikitext",
+                "subset": "wikitext-2-raw-v1",
+                "split": "train"
+            },
+            "pre_process_data_config": {
+                "strategy": "line-by-line",
+                "add_special_tokens": true,
+                "max_samples": 256,
+                "max_seq_len": 1024
+            }
+        }
+    ],
+    "passes": {
+        "mnb_to_qdq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": true,
+            "save_as_external_data": true
+        },
+        "static_quant": {
+            "type": "OnnxStaticQuantization",
+            "data_config": "wikitext2_train_act",
+            "activation_type": "uint16",
+            "precision": "uint8",
+            "calibration_providers": ["CPUExecutionProvider"],
+            "quant_preprocess": true,
+            "op_types_to_exclude": [
+                "GatherBlockQuantized",
+                "GroupQueryAttention",
+                "MatMulNBits"
+            ],
+            "save_as_external_data": true
+        },
+        "static_llm": {
+            "type": "StaticLLM",
+            "batch_size": 1,
+            "context_length": 64
+        },
+        "ep_context": {
+            "type": "EPContextBinaryGenerator",
+            "provider_options": {
+                "htp_performance_mode": "burst",
+                "htp_graph_finalization_optimization_mode": "3",
+                "soc_model": "60"
+            },
+            "weight_sharing": true
+        }
+    },
+    "target": "qnn_system",
+    "output_dir": "model/gemma4_e2b_qnn_gguf",
+    "cache_dir": "cache",
+    "no_artifacts": true,
+    "evaluate_input_model": false
+}

--- a/google-gemma-4-E2B-it/QNN/config_gguf.json
+++ b/google-gemma-4-E2B-it/QNN/config_gguf.json
@@ -30,12 +30,6 @@
         }
     ],
     "passes": {
-        "mnb_to_qdq": {
-            "type": "MatMulNBitsToQDQ",
-            "use_int4": true,
-            "add_zero_point": true,
-            "save_as_external_data": true
-        },
         "static_quant": {
             "type": "OnnxStaticQuantization",
             "data_config": "wikitext2_train_act",

--- a/google-gemma-4-E2B-it/QNN/info.yml
+++ b/google-gemma-4-E2B-it/QNN/info.yml
@@ -10,4 +10,4 @@ recipes:
     devices:
       - npu
     eps: QNNExecutionProvider
-name: gemma4_e2b_qnn
+name: gemma4-e2b-qnn

--- a/google-gemma-4-E2B-it/QNN/info.yml
+++ b/google-gemma-4-E2B-it/QNN/info.yml
@@ -3,10 +3,16 @@ keywords:
     - qnn
     - gemma4
     - mobius
+    - gguf
 arch: gemma
 recipes:
   - name: gemma4-e2b-qnn
     file: config.json
+    devices:
+      - npu
+    eps: QNNExecutionProvider
+  - name: gemma4-e2b-qnn-gguf
+    file: config_gguf.json
     devices:
       - npu
     eps: QNNExecutionProvider

--- a/google-gemma-4-E2B-it/QNN/info.yml
+++ b/google-gemma-4-E2B-it/QNN/info.yml
@@ -1,0 +1,13 @@
+keywords:
+    - foundry-local
+    - qnn
+    - gemma4
+    - mobius
+arch: gemma
+recipes:
+  - name: gemma4-e2b-qnn
+    file: config.json
+    devices:
+      - npu
+    eps: QNNExecutionProvider
+name: gemma4_e2b_qnn

--- a/google-gemma-4-E2B-it/QNN/requirements.txt
+++ b/google-gemma-4-E2B-it/QNN/requirements.txt
@@ -1,4 +1,5 @@
 datasets
+gguf
 mobius-ai
 olive-ai
 onnxruntime-gpu

--- a/google-gemma-4-E2B-it/QNN/requirements.txt
+++ b/google-gemma-4-E2B-it/QNN/requirements.txt
@@ -1,6 +1,5 @@
 datasets
 mobius-ai
-olive-ai==0.9.3
-# these are the versions the recipes were last validated with
-onnxruntime-gpu==1.21.1
-transformers>=5.0
+olive-ai
+onnxruntime-gpu
+transformers

--- a/google-gemma-4-E2B-it/QNN/requirements.txt
+++ b/google-gemma-4-E2B-it/QNN/requirements.txt
@@ -1,0 +1,5 @@
+datasets
+mobius-ai
+olive-ai
+onnxruntime-gpu
+transformers>=5.0

--- a/google-gemma-4-E2B-it/QNN/requirements.txt
+++ b/google-gemma-4-E2B-it/QNN/requirements.txt
@@ -1,5 +1,6 @@
 datasets
 mobius-ai
-olive-ai
-onnxruntime-gpu
+olive-ai==0.9.3
+# these are the versions the recipes were last validated with
+onnxruntime-gpu==1.21.1
 transformers>=5.0


### PR DESCRIPTION
## Summary

Adds `google-gemma-4-E2B-it/QNN/` — an exploratory Olive recipe for running [`google/gemma-4-E2B-it`](https://huggingface.co/google/gemma-4-E2B-it) on the Qualcomm **Hexagon NPU (HTP)** via the QNN ONNX Runtime execution provider (Snapdragon X / Copilot+ PC).

Still marked **WIP** — the full end-to-end EPContext AOT compile is not yet productized — but this session added substantial **hardware-validated** findings on a Snapdragon X (ORT 1.27, onnxruntime-qnn 2.4.0, QNN SDK 2.48.40, HTP V73), including a model that runs **fully on the HTP** and measured NPU/GPU/CPU tok/s.

## Two build paths

| Path | Config | INT4 source | Cost |
|---|---|---|---|
| **GGUF-direct (recommended)** | `config_gguf.json` | reuse [`unsloth/gemma-4-E2B-it-GGUF`](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF) Q4_K_M weights | cheap — no calibration/RTN |
| HF-source | `config.json` | quantize fp32 weights with `OnnxKQuantQuantization` | expensive (RTN over 262k vocab) |

The **GGUF-direct** path uses `mobius build-gguf` to re-pack the already-INT4 unsloth GGUF into ONNX, skipping the expensive quant pass. Verified end-to-end to generate correct text on ORT CPU ("The capital of France is **Paris**.").

## What was validated this session

1. **Full HTP op offload (mobius lowering).** The QNN HTP backend has no kernel for the fused opset-24 `Attention`, `com.microsoft::MatMulNBits`, `RotaryEmbedding`, `TensorScatter`, `Tile`, `Range`, `BitwiseAnd`/`BitShift` — each forces its node to CPU. mobius `--ep qnn` now lowers **all** of them to HTP-supported primitives (`Attention`→SDPA, `RotaryEmbedding`→rotate-half, `TensorScatter`→`ScatterND`, `Tile`→`Expand`, `Range`→`Constant`+`Slice`, `MatMulNBits`→QDQ, nibble-unpack constant-folds). **Result: a non-quantized fp16 gemma4 static model composes and runs *entirely* on the HTP** (verified with `session.disable_cpu_ep_fallback=1`). Requires [onnxruntime/mobius#407](https://github.com/onnxruntime/mobius/pull/407).

2. **gemma4 static KV cache** (mobius `5d804b7`) — the prerequisite for HTP static shapes. `--static-cache --max-seq-len N` emits a fully static, decomposed, QDQ graph; static decode matches the dynamic reference to ~1e-6.

3. **INT4 on HTP requires per-channel + quantized activations.** Weight-only `DequantizeLinear`→`MatMul` (float activations) runs on HTP only for *per-tensor* weights; *per-channel* / *blocked* is CPU-forced. HTP claims per-channel int4/int8 only inside a **full int QDQ group** (quantized activations). **GGUF Q4_K blocked quant (`block_size=32`) is CPU-forced at any bit width** and must be re-quantized to per-channel. Filed [onnxruntime/onnxruntime-qnn#650](https://github.com/onnxruntime/onnxruntime-qnn/issues/650) (and #646 for the fused-Attention gap).

4. **Measured decode tok/s** (E2B dims, per-channel QDQ, extrapolated 35-layer transformer):

   | Quantization | HTP (NPU) | CPU |
   |---|---|---|
   | int4 per-channel + uint8 act | 16.4 tok/s | 17.5 tok/s |
   | int8 per-channel + uint8 act | 16.6 tok/s | 16.7 tok/s |

   References: mobius dynamic INT4 CPU 18.2, llama.cpp CPU 43.7. **Batch-1 decode is memory-bound → the NPU ≈ CPU here; NPU value is power efficiency / prefill / batching, not single-stream decode.** IO-binding (in-place KV) and EPContext gave no decode speedup (CPU/HTP share SoC DRAM; EPContext only speeds loading).

5. **GPU (Adreno) vs NPU (HTP) backend** (10-layer E2B FFN, best-of-3):

   | Model | CPU EP | QNN GPU | QNN HTP |
   |---|---|---|---|
   | int8 QDQ | 2.75 ms | 3.03 ms | 2.92 ms |
   | fp16 | 11.18 ms | 10.51 ms | **9.38 ms** |

   Both QNN backends genuinely engage (GPU beats CPU on fp16), but the **HTP/NPU is fastest**; the GPU sits between CPU and NPU. `QnnCpu.dll` is not shipped in the wheel.

## Pipeline (GGUF-direct)

```
unsloth GGUF (Q4_K_M INT4)
   ↓ mobius build-gguf --ep qnn --static-cache   static, decomposed SDPA + QDQ INT4, full HTP lowering
   ↓ OnnxStaticQuantization                       per-channel weights + uint8 activations (calibrated)
   ↓ StaticLLM                                     static shapes
   ↓ EPContextBinaryGenerator                      HTP EPContext blobs
```

`config_gguf.json` drops `MobiusBuilder`, `OnnxKQuantQuantization`, and `MatMulNBitsToQDQ` (the mobius `--ep qnn` build already emits decomposed Attention + QDQ INT4).

## Remaining work

- Full-model single-graph HTP compose exceeds the finalization budget at 35 layers / 262k vocab → needs `SplitModel` + weight-shared EPContext chunks (embeddings pinned to CPU to dodge the 4GB per-layer-embedding 32-bit static-tensor overflow).
- `StaticLLM` assumes the ORT-GenAI static-KV contract (GQA + `past_seq_len`/`total_seq_len`); mobius output uses decomposed attention + `attention_mask`/`position_ids`.
- Logit soft-cap (`cap * tanh(x/cap)`) may need a `RemoveLogitSoftcap` surgery or host post-processing.
- Re-quant GGUF blocked INT4 → per-channel for HTP integer matmuls (see finding 3).

## Asks for review

- Anyone with Snapdragon HW to run the full `config_gguf.json` AOT compile and report which pass breaks on the split step?
- Is the fp16-fully-on-HTP path (4× larger, chunked) or the INT4-per-channel + static-activation-quant path the better deployment target?

## Related

- [onnxruntime/mobius#407](https://github.com/onnxruntime/mobius/pull/407) — gemma4 static cache + full-HTP-offload lowering (required)
- onnxruntime/onnxruntime-qnn#646, #650 — filed QNN HTP op/quant gaps
- microsoft/olive-recipes#381 — CPU + CUDA Gemma 4 recipes this complements
- microsoft/Olive#2472 — MobiusBuilder groundwork
