### PR TITLE
Switch Qwen3.5-0.8B int4 quant to k_quant_mixed (block_size=32)

### DIFF
--- a/Qwen-Qwen3.5-0.8B/builtin/cuda/text.json
+++ b/Qwen-Qwen3.5-0.8B/builtin/cuda/text.json
@@ -8,7 +8,8 @@
             "type": "ModelBuilder",
             "precision": "int4",
             "int4_accuracy_level": 4,
-            "int4_algo_config": "k_quant_linear",
+            "int4_algo_config": "k_quant_mixed",
+            "int4_block_size": 32,
             "extra_options": {
                 "filename": "text.onnx",
                 "prune_lm_head": true

--- a/Qwen-Qwen3.5-0.8B/builtin/webgpu/text.json
+++ b/Qwen-Qwen3.5-0.8B/builtin/webgpu/text.json
@@ -19,7 +19,8 @@
             "type": "ModelBuilder",
             "precision": "int4",
             "int4_accuracy_level": 4,
-            "int4_algo_config": "k_quant_linear",
+            "int4_algo_config": "k_quant_mixed",
+            "int4_block_size": 32,
             "extra_options": {
                 "filename": "text.onnx",
                 "prune_lm_head": true


### PR DESCRIPTION
## Summary

Update the int4 quantization configuration for **Qwen3.5-0.8B** in both the CUDA and WebGPU recipes:

- `int4_algo_config`: `k_quant_linear` → `k_quant_mixed`
- `int4_block_size`: add `32`

## Files changed

- `Qwen-Qwen3.5-0.8B/builtin/cuda/text.json`
- `Qwen-Qwen3.5-0.8B/builtin/webgpu/text.json`

## Motivation

`k_quant_mixed` with a 32-block size produces better accuracy/quality for the Qwen3.5-0.8B text model than the previous `k_quant_linear` setting, while keeping the int4 precision and accuracy level unchanged.
