### PR TITLE
Add tencent/Hy-MT2-1.8B ONNX recipes (Mobius + K-Quant)

### DIFF
--- a/tencent-Hy-MT2-1.8B/LICENSE
+++ b/tencent-Hy-MT2-1.8B/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tencent-Hy-MT2-1.8B/README.md
+++ b/tencent-Hy-MT2-1.8B/README.md
@@ -36,6 +36,8 @@ Install ONNX Runtime GenAI:
 | Recipe | Pipeline | Output dir |
 |---|---|---|
 | `cpu/fp32/config.json` | `MobiusBuilder(fp32)` | `cpu/fp32/models` |
+| `cpu/fp16/config.json` | `MobiusBuilder(fp16)` | `cpu/fp16/models` |
+| `cpu/bf16/config.json` | `MobiusBuilder(bf16)` | `cpu/bf16/models` |
 | `cpu/int4/config.json` | `MobiusBuilder(fp32)` → `OnnxKQuantQuantization(bits=4, block_size=32)` | `cpu/int4/models` |
 | `cuda/fp16/config.json` | `MobiusBuilder(fp16)` | `cuda/fp16/models` |
 | `cuda/bf16/config.json` | `MobiusBuilder(bf16)` | `cuda/bf16/models` |

--- a/tencent-Hy-MT2-1.8B/README.md
+++ b/tencent-Hy-MT2-1.8B/README.md
@@ -2,8 +2,9 @@
 
 Olive recipes that export [tencent/Hy-MT2-1.8B](https://huggingface.co/tencent/Hy-MT2-1.8B)
 to ONNX via the [`MobiusBuilder`](https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/mobius_model_builder.py)
-pass and (optionally) quantize the decoder for INT4 deployment — with Olive's
-K-Quant (Q4_K_M) pass on CPU, or GPTQ + RTN on CUDA.
+pass and (optionally) quantize the decoder for INT4 deployment with Olive's
+K-Quant (Q4_K_M) pass. The CUDA INT4 recipe additionally INT4-quantizes the tied
+input-embedding / LM-head table and shares it as a single weight.
 
 Hy-MT2-1.8B is a "fast-thinking" multilingual **translation** model
 supporting 33 languages. Architecturally it is a `HunYuanDenseV1` decoder:
@@ -22,8 +23,8 @@ post-processing required.
 pip install -r requirements.txt
 ```
 
-`requirements.txt` pulls in `olive-ai[gpu]`, `mobius-ai`, `gptqmodel`
-(GPTQ quantization for the CUDA INT4 recipe), and `lm-eval`.
+`requirements.txt` pulls in `olive-ai[gpu]`, `mobius-ai`, and `lm-eval`.
+Install `cupy-cuda12x` to accelerate K-Quant on the GPU.
 
 Install ONNX Runtime GenAI:
 
@@ -42,17 +43,22 @@ Install ONNX Runtime GenAI:
 | `cpu/int4/config.json` | `MobiusBuilder(fp32)` → `OnnxKQuantQuantization(bits=4, block_size=32)` | `cpu/int4/models` |
 | `cuda/fp16/config.json` | `MobiusBuilder(fp16)` | `cuda/fp16/models` |
 | `cuda/bf16/config.json` | `MobiusBuilder(bf16)` | `cuda/bf16/models` |
-| `cuda/int4/config.json` | `gptq(bits=4)` → `rtn(bits=4, lm_head, embeds)` → `MobiusBuilder(fp16)` | `cuda/int4/models` |
+| `cuda/int4/config.json` | `MobiusBuilder(fp16)` → `OnnxKQuantQuantization(body)` → `OnnxBlockWiseRtnQuantization(embedding)` → `GraphSurgeries[TieWordEmbeddings]` | `cuda/int4/models` |
 
 INT4 is recommended for most deployments — at 1.8B parameters it is a ~1 GB
-on-disk model with negligible impact on translation quality. The CPU INT4
-recipe uses Olive's K-Quant (Q4_K_M) pass; install `cupy-cuda12x` for a large
-speedup during K-Quant. The CUDA INT4 recipe instead quantizes the decoder
-weights with Olive's `gptq` (GPTQ, wikitext-calibrated) and `rtn`
-(round-to-nearest, for the tied `lm_head` / `embed_tokens`) passes — written
-into the HuggingFace `quantization_config` — which `MobiusBuilder` then lowers
-to `MatMulNBits`. GPTQ calibration runs on the GPU, so `gptqmodel` and a CUDA
-build of PyTorch are required.
+on-disk model with negligible impact on translation quality. Install
+`cupy-cuda12x` for a large speedup during K-Quant.
+
+Both INT4 recipes quantize the transformer body with Olive's K-Quant (Q4_K_M)
+pass. The **CUDA INT4** recipe additionally INT4-quantizes the large tied
+input-embedding table (`OnnxBlockWiseRtnQuantization` → `GatherBlockQuantized`)
+and rebuilds the tied LM head to **share that same INT4 table** as a
+`MatMulNBits` (`TieWordEmbeddings`), so the word-embedding matrix is stored once
+as INT4 instead of once as INT4 plus once as float16. This yields the smallest
+on-disk model (~1.03 GB) at K-Quant body quality.
+
+> The CUDA INT4 recipe requires the `TieWordEmbeddings` reuse mode from
+> [microsoft/Olive#2549](https://github.com/microsoft/Olive/pull/2549).
 
 > BF16 MatMul is not implemented on the ORT CPU EP, so the `bf16` variant
 > runs on CUDA / DML / WebGPU only.
@@ -72,7 +78,7 @@ olive run --config cuda/fp16/config.json
 # CUDA, BF16
 olive run --config cuda/bf16/config.json
 
-# CUDA, INT4 (GPTQ + RTN, runs on GPU)
+# CUDA, INT4 (K-Quant body + shared-INT4 tied embedding)
 olive run --config cuda/int4/config.json
 ```
 
@@ -130,5 +136,5 @@ HF     : The waters of the Yellow River come from the sky
 - Mobius: <https://github.com/onnxruntime/mobius>
 - Olive `MobiusBuilder` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/mobius_model_builder.py>
 - Olive `OnnxKQuantQuantization` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/kquant_quantization.py>
-- Olive `gptq` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/pytorch/gptq.py>
-- Olive `rtn` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/pytorch/rtn.py>
+- Olive `OnnxBlockWiseRtnQuantization` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/rtn_quantization.py>
+- Olive `TieWordEmbeddings` graph surgery: <https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/graph_surgeries.py>

--- a/tencent-Hy-MT2-1.8B/README.md
+++ b/tencent-Hy-MT2-1.8B/README.md
@@ -1,0 +1,124 @@
+# Hy-MT2-1.8B (tencent/Hy-MT2-1.8B)
+
+Olive recipes that export [tencent/Hy-MT2-1.8B](https://huggingface.co/tencent/Hy-MT2-1.8B)
+to ONNX via the [`MobiusBuilder`](https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/mobius_model_builder.py)
+pass and (optionally) quantize the decoder with Olive's K-Quant (Q4_K_M)
+pass for INT4 deployment.
+
+Hy-MT2-1.8B is a "fast-thinking" multilingual **translation** model
+supporting 33 languages. Architecturally it is a `HunYuanDenseV1` decoder:
+grouped-query attention (16 query / 4 KV heads, head_dim 128), per-head
+QK-norm, tied input/output embeddings, SwiGLU MLP, and dynamic-NTK RoPE
+(`alpha = 1000`). `MobiusBuilder` builds the decoder directly with the fused
+GroupQueryAttention path on CUDA.
+
+`MobiusBuilder` writes a fully-formed ORT GenAI package (`genai_config.json`,
+`tokenizer.json`, `chat_template.jinja`) alongside the ONNX files — no
+post-processing required.
+
+## Prerequisites
+
+```bash
+pip install -r requirements.txt
+```
+
+`requirements.txt` pulls in `olive-ai[gpu]`, `mobius-ai`, and `lm-eval`.
+
+Install ONNX Runtime GenAI:
+
+| Device | Install Command |
+|--------|-----------------|
+| CPU | `pip install onnxruntime-genai` |
+| GPU (CUDA) | `pip install onnxruntime-genai-cuda` |
+
+## Recipes
+
+| Recipe | Pipeline | Output dir |
+|---|---|---|
+| `cpu/fp32/config.json` | `MobiusBuilder(fp32)` | `cpu/fp32/models` |
+| `cpu/int4/config.json` | `MobiusBuilder(fp32)` → `OnnxKQuantQuantization(bits=4, block_size=32)` | `cpu/int4/models` |
+| `cuda/fp16/config.json` | `MobiusBuilder(fp16)` | `cuda/fp16/models` |
+| `cuda/bf16/config.json` | `MobiusBuilder(bf16)` | `cuda/bf16/models` |
+| `cuda/int4/config.json` | `MobiusBuilder(fp16)` → `OnnxKQuantQuantization(bits=4, block_size=32)` | `cuda/int4/models` |
+
+INT4 (K-Quant Q4_K_M) is recommended for most deployments — at 1.8B
+parameters it is a ~1 GB on-disk model with negligible impact on translation
+quality. K-Quant is significantly faster with GPU acceleration — install
+`cupy-cuda12x` for a large speedup during quantization.
+
+> BF16 MatMul is not implemented on the ORT CPU EP, so the `bf16` variant
+> runs on CUDA / DML / WebGPU only.
+
+## Build
+
+```bash
+# CPU, full precision
+olive run --config cpu/fp32/config.json
+
+# CPU, INT4 (K-Quant)
+olive run --config cpu/int4/config.json
+
+# CUDA, FP16
+olive run --config cuda/fp16/config.json
+
+# CUDA, BF16
+olive run --config cuda/bf16/config.json
+
+# CUDA, INT4 (K-Quant)
+olive run --config cuda/int4/config.json
+```
+
+Each command produces the full ORT GenAI package in the recipe's
+`output_dir`:
+
+```
+<output_dir>/
+├── model.onnx              # Decoder-only transformer
+├── model.onnx.data         # External weights
+├── genai_config.json       # Runtime configuration
+├── chat_template.jinja
+├── tokenizer.json
+└── tokenizer_config.json
+```
+
+## Inference
+
+```bash
+# CPU, fp32
+python inference.py --source "今天天气真好。" --target-lang English
+
+# CPU INT4
+python inference.py --variant int4 --source "Hello, world!" --target-lang Chinese
+
+# CUDA INT4
+python inference.py --device gpu --variant int4 --source "Knowledge is power." \
+    --target-lang French
+
+# CUDA BF16, interactive
+python inference.py --device gpu --variant bf16 --interactive
+```
+
+The Hy-MT BPE vocab uses a custom regex pre-tokenizer that ort-extensions
+does not currently round-trip, so `inference.py` tokenizes / detokenizes with
+the HuggingFace tokenizer and feeds raw token IDs to `og.Generator` (this
+still exercises the full ORT GenAI inference path).
+
+## Verification
+
+The mobius ONNX export is verified token-for-token against HuggingFace
+`transformers` (greedy decode, L4 prefill logits + L5 generation) in the
+[mobius repository](https://github.com/onnxruntime/mobius)
+(`tests/e2e_golden_test.py`, case `causal-lm/hy-mt2-1_8b`). Example:
+
+```
+source : 黄河之水天上来
+ONNX   : The waters of the Yellow River come from the sky
+HF     : The waters of the Yellow River come from the sky
+```
+
+## References
+
+- Hy-MT2 model card: <https://huggingface.co/tencent/Hy-MT2-1.8B>
+- Mobius: <https://github.com/onnxruntime/mobius>
+- Olive `MobiusBuilder` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/mobius_model_builder.py>
+- Olive `OnnxKQuantQuantization` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/kquant_quantization.py>

--- a/tencent-Hy-MT2-1.8B/README.md
+++ b/tencent-Hy-MT2-1.8B/README.md
@@ -23,8 +23,9 @@ post-processing required.
 pip install -r requirements.txt
 ```
 
-`requirements.txt` pulls in `olive-ai[gpu]`, `mobius-ai`, and `lm-eval`.
-Install `cupy-cuda12x` to accelerate K-Quant on the GPU.
+`requirements.txt` pulls in `olive-ai[gpu]`, `mobius-ai`, `gptqmodel` (for the
+GPTQ INT4 recipe), and `lm-eval`. Install `cupy-cuda12x` to accelerate K-Quant on
+the GPU.
 
 Install ONNX Runtime GenAI:
 
@@ -44,21 +45,31 @@ Install ONNX Runtime GenAI:
 | `cuda/fp16/config.json` | `MobiusBuilder(fp16)` | `cuda/fp16/models` |
 | `cuda/bf16/config.json` | `MobiusBuilder(bf16)` | `cuda/bf16/models` |
 | `cuda/int4/config.json` | `MobiusBuilder(fp16)` → `OnnxKQuantQuantization(body)` → `OnnxBlockWiseRtnQuantization(embedding)` → `GraphSurgeries[TieWordEmbeddings]` | `cuda/int4/models` |
+| `cuda/int4_gptq/config.json` | `gptq(bits=4)` → `rtn(bits=4, lm_head, embeds)` → `MobiusBuilder(fp16)` | `cuda/int4_gptq/models` |
 
 INT4 is recommended for most deployments — at 1.8B parameters it is a ~1 GB
 on-disk model with negligible impact on translation quality. Install
 `cupy-cuda12x` for a large speedup during K-Quant.
 
-Both INT4 recipes quantize the transformer body with Olive's K-Quant (Q4_K_M)
-pass. The **CUDA INT4** recipe additionally INT4-quantizes the large tied
-input-embedding table (`OnnxBlockWiseRtnQuantization` → `GatherBlockQuantized`)
-and rebuilds the tied LM head to **share that same INT4 table** as a
-`MatMulNBits` (`TieWordEmbeddings`), so the word-embedding matrix is stored once
-as INT4 instead of once as INT4 plus once as float16. This yields the smallest
-on-disk model (~1.03 GB) at K-Quant body quality.
+There are two CUDA INT4 recipes; both produce a ~1.03 GB model with a shared INT4
+tied embedding / LM head, and differ only in how the **transformer body** is
+quantized:
 
-> The CUDA INT4 recipe requires the `TieWordEmbeddings` reuse mode from
-> [microsoft/Olive#2549](https://github.com/microsoft/Olive/pull/2549).
+- **`cuda/int4/config.json` (K-Quant, recommended)** — quantizes the body with
+  Olive's K-Quant (Q4_K_M) pass, then INT4-quantizes the tied input-embedding
+  table (`OnnxBlockWiseRtnQuantization` → `GatherBlockQuantized`) and rebuilds the
+  tied LM head to **share that same INT4 table** as a `MatMulNBits`
+  (`TieWordEmbeddings`). Highest body quality.
+  Requires the `TieWordEmbeddings` reuse mode from
+  [microsoft/Olive#2549](https://github.com/microsoft/Olive/pull/2549).
+- **`cuda/int4_gptq/config.json` (GPTQ)** — quantizes the whole model (body +
+  tied embedding / LM head) with Olive's `gptq` (GPTQ, wikitext-calibrated) and
+  `rtn` passes, written into the HuggingFace `quantization_config`, which
+  `MobiusBuilder` then lowers to `MatMulNBits` / `GatherBlockQuantized`. GPTQ
+  calibration runs on the GPU and needs `gptqmodel` plus a CUDA build of PyTorch.
+
+The two are the same size and speed; K-Quant has slightly higher fidelity to the
+float model, while GPTQ needs no extra Olive graph surgery.
 
 > BF16 MatMul is not implemented on the ORT CPU EP, so the `bf16` variant
 > runs on CUDA / DML / WebGPU only.
@@ -80,6 +91,9 @@ olive run --config cuda/bf16/config.json
 
 # CUDA, INT4 (K-Quant body + shared-INT4 tied embedding)
 olive run --config cuda/int4/config.json
+
+# CUDA, INT4 (GPTQ body + tied embedding, runs on GPU)
+olive run --config cuda/int4_gptq/config.json
 ```
 
 Each command produces the full ORT GenAI package in the recipe's
@@ -138,3 +152,5 @@ HF     : The waters of the Yellow River come from the sky
 - Olive `OnnxKQuantQuantization` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/kquant_quantization.py>
 - Olive `OnnxBlockWiseRtnQuantization` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/rtn_quantization.py>
 - Olive `TieWordEmbeddings` graph surgery: <https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/graph_surgeries.py>
+- Olive `gptq` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/pytorch/gptq.py>
+- Olive `rtn` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/pytorch/rtn.py>

--- a/tencent-Hy-MT2-1.8B/README.md
+++ b/tencent-Hy-MT2-1.8B/README.md
@@ -2,8 +2,8 @@
 
 Olive recipes that export [tencent/Hy-MT2-1.8B](https://huggingface.co/tencent/Hy-MT2-1.8B)
 to ONNX via the [`MobiusBuilder`](https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/mobius_model_builder.py)
-pass and (optionally) quantize the decoder with Olive's K-Quant (Q4_K_M)
-pass for INT4 deployment.
+pass and (optionally) quantize the decoder for INT4 deployment — with Olive's
+K-Quant (Q4_K_M) pass on CPU, or GPTQ + RTN on CUDA.
 
 Hy-MT2-1.8B is a "fast-thinking" multilingual **translation** model
 supporting 33 languages. Architecturally it is a `HunYuanDenseV1` decoder:
@@ -22,7 +22,8 @@ post-processing required.
 pip install -r requirements.txt
 ```
 
-`requirements.txt` pulls in `olive-ai[gpu]`, `mobius-ai`, and `lm-eval`.
+`requirements.txt` pulls in `olive-ai[gpu]`, `mobius-ai`, `gptqmodel`
+(GPTQ quantization for the CUDA INT4 recipe), and `lm-eval`.
 
 Install ONNX Runtime GenAI:
 
@@ -41,12 +42,17 @@ Install ONNX Runtime GenAI:
 | `cpu/int4/config.json` | `MobiusBuilder(fp32)` → `OnnxKQuantQuantization(bits=4, block_size=32)` | `cpu/int4/models` |
 | `cuda/fp16/config.json` | `MobiusBuilder(fp16)` | `cuda/fp16/models` |
 | `cuda/bf16/config.json` | `MobiusBuilder(bf16)` | `cuda/bf16/models` |
-| `cuda/int4/config.json` | `MobiusBuilder(fp16)` → `OnnxKQuantQuantization(bits=4, block_size=32)` | `cuda/int4/models` |
+| `cuda/int4/config.json` | `gptq(bits=4)` → `rtn(bits=4, lm_head, embeds)` → `MobiusBuilder(fp16)` | `cuda/int4/models` |
 
-INT4 (K-Quant Q4_K_M) is recommended for most deployments — at 1.8B
-parameters it is a ~1 GB on-disk model with negligible impact on translation
-quality. K-Quant is significantly faster with GPU acceleration — install
-`cupy-cuda12x` for a large speedup during quantization.
+INT4 is recommended for most deployments — at 1.8B parameters it is a ~1 GB
+on-disk model with negligible impact on translation quality. The CPU INT4
+recipe uses Olive's K-Quant (Q4_K_M) pass; install `cupy-cuda12x` for a large
+speedup during K-Quant. The CUDA INT4 recipe instead quantizes the decoder
+weights with Olive's `gptq` (GPTQ, wikitext-calibrated) and `rtn`
+(round-to-nearest, for the tied `lm_head` / `embed_tokens`) passes — written
+into the HuggingFace `quantization_config` — which `MobiusBuilder` then lowers
+to `MatMulNBits`. GPTQ calibration runs on the GPU, so `gptqmodel` and a CUDA
+build of PyTorch are required.
 
 > BF16 MatMul is not implemented on the ORT CPU EP, so the `bf16` variant
 > runs on CUDA / DML / WebGPU only.
@@ -66,7 +72,7 @@ olive run --config cuda/fp16/config.json
 # CUDA, BF16
 olive run --config cuda/bf16/config.json
 
-# CUDA, INT4 (K-Quant)
+# CUDA, INT4 (GPTQ + RTN, runs on GPU)
 olive run --config cuda/int4/config.json
 ```
 
@@ -124,3 +130,5 @@ HF     : The waters of the Yellow River come from the sky
 - Mobius: <https://github.com/onnxruntime/mobius>
 - Olive `MobiusBuilder` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/mobius_model_builder.py>
 - Olive `OnnxKQuantQuantization` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/onnx/kquant_quantization.py>
+- Olive `gptq` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/pytorch/gptq.py>
+- Olive `rtn` pass: <https://github.com/microsoft/Olive/tree/main/olive/passes/pytorch/rtn.py>

--- a/tencent-Hy-MT2-1.8B/README.md
+++ b/tencent-Hy-MT2-1.8B/README.md
@@ -42,10 +42,12 @@ Install ONNX Runtime GenAI:
 | `cpu/fp16/config.json` | `MobiusBuilder(fp16)` | `cpu/fp16/models` |
 | `cpu/bf16/config.json` | `MobiusBuilder(bf16)` | `cpu/bf16/models` |
 | `cpu/int4/config.json` | `MobiusBuilder(fp32)` → `OnnxKQuantQuantization(bits=4, block_size=32)` | `cpu/int4/models` |
+| `cpu/int4_tie/config.json` | `MobiusBuilder(fp32)` → `OnnxKQuantQuantization(body)` → `OnnxBlockWiseRtnQuantization(embedding)` → `GraphSurgeries[TieWordEmbeddings]` | `cpu/int4_tie/models` |
 | `cuda/fp16/config.json` | `MobiusBuilder(fp16)` | `cuda/fp16/models` |
 | `cuda/bf16/config.json` | `MobiusBuilder(bf16)` | `cuda/bf16/models` |
 | `cuda/int4/config.json` | `MobiusBuilder(fp16)` → `OnnxKQuantQuantization(body)` → `OnnxBlockWiseRtnQuantization(embedding)` → `GraphSurgeries[TieWordEmbeddings]` | `cuda/int4/models` |
 | `cuda/int4_gptq/config.json` | `gptq(bits=4)` → `rtn(bits=4, lm_head, embeds)` → `MobiusBuilder(fp16)` | `cuda/int4_gptq/models` |
+| `webgpu/int4_tie/config.json` | `MobiusBuilder(fp16)` → `OnnxKQuantQuantization(body)` → `OnnxBlockWiseRtnQuantization(embedding)` → `GraphSurgeries[TieWordEmbeddings]` | `webgpu/int4_tie/models` |
 
 INT4 is recommended for most deployments — at 1.8B parameters it is a ~1 GB
 on-disk model with negligible impact on translation quality. Install
@@ -71,6 +73,12 @@ quantized:
 The two are the same size and speed; K-Quant has slightly higher fidelity to the
 float model, while GPTQ needs no extra Olive graph surgery.
 
+`cpu/int4_tie/config.json` and `webgpu/int4_tie/config.json` apply the same
+K-Quant-body + shared-INT4-tied-embedding pipeline as `cuda/int4` for the CPU and
+WebGPU execution providers (CPU uses `fp32` scales, WebGPU uses `fp16`). They also
+require the `TieWordEmbeddings` reuse mode from
+[microsoft/Olive#2549](https://github.com/microsoft/Olive/pull/2549).
+
 > BF16 MatMul is not implemented on the ORT CPU EP, so the `bf16` variant
 > runs on CUDA / DML / WebGPU only.
 
@@ -83,6 +91,9 @@ olive run --config cpu/fp32/config.json
 # CPU, INT4 (K-Quant)
 olive run --config cpu/int4/config.json
 
+# CPU, INT4 (K-Quant body + shared-INT4 tied embedding)
+olive run --config cpu/int4_tie/config.json
+
 # CUDA, FP16
 olive run --config cuda/fp16/config.json
 
@@ -94,6 +105,9 @@ olive run --config cuda/int4/config.json
 
 # CUDA, INT4 (GPTQ body + tied embedding, runs on GPU)
 olive run --config cuda/int4_gptq/config.json
+
+# WebGPU, INT4 (K-Quant body + shared-INT4 tied embedding)
+olive run --config webgpu/int4_tie/config.json
 ```
 
 Each command produces the full ORT GenAI package in the recipe's

--- a/tencent-Hy-MT2-1.8B/README.md
+++ b/tencent-Hy-MT2-1.8B/README.md
@@ -53,7 +53,7 @@ INT4 is recommended for most deployments — at 1.8B parameters it is a ~1 GB
 on-disk model with negligible impact on translation quality. Install
 `cupy-cuda12x` for a large speedup during K-Quant.
 
-There are two CUDA INT4 recipes; both produce a ~1.03 GB model with a shared INT4
+There are two CUDA INT4 recipes; both produce a ~1.03 GiB model with a shared INT4
 tied embedding / LM head, and differ only in how the **transformer body** is
 quantized:
 
@@ -75,8 +75,10 @@ float model, while GPTQ needs no extra Olive graph surgery.
 
 `cpu/int4_tie/config.json` and `webgpu/int4_tie/config.json` apply the same
 K-Quant-body + shared-INT4-tied-embedding pipeline as `cuda/int4` for the CPU and
-WebGPU execution providers (CPU uses `fp32` scales, WebGPU uses `fp16`). They also
-require the `TieWordEmbeddings` reuse mode from
+WebGPU execution providers. The `webgpu` output is byte-for-byte identical to
+`cuda/int4` (both fp16 scales, ~1.03 GiB); `cpu` uses fp32 scales (~1.19 GiB) since
+the CPU EP has limited fp16 kernel support. All three require the
+`TieWordEmbeddings` reuse mode from
 [microsoft/Olive#2549](https://github.com/microsoft/Olive/pull/2549).
 
 > BF16 MatMul is not implemented on the ORT CPU EP, so the `bf16` variant

--- a/tencent-Hy-MT2-1.8B/cpu/bf16/config.json
+++ b/tencent-Hy-MT2-1.8B/cpu/bf16/config.json
@@ -1,0 +1,7 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "tencent/Hy-MT2-1.8B" },
+    "passes": {
+        "mobius_build": { "type": "MobiusBuilder", "precision": "bf16" }
+    },
+    "output_dir": "cpu/bf16/models"
+}

--- a/tencent-Hy-MT2-1.8B/cpu/fp16/config.json
+++ b/tencent-Hy-MT2-1.8B/cpu/fp16/config.json
@@ -1,0 +1,7 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "tencent/Hy-MT2-1.8B" },
+    "passes": {
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp16" }
+    },
+    "output_dir": "cpu/fp16/models"
+}

--- a/tencent-Hy-MT2-1.8B/cpu/fp32/config.json
+++ b/tencent-Hy-MT2-1.8B/cpu/fp32/config.json
@@ -1,0 +1,7 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "tencent/Hy-MT2-1.8B" },
+    "passes": {
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp32" }
+    },
+    "output_dir": "cpu/fp32/models"
+}

--- a/tencent-Hy-MT2-1.8B/cpu/int4/config.json
+++ b/tencent-Hy-MT2-1.8B/cpu/int4/config.json
@@ -1,0 +1,13 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "tencent/Hy-MT2-1.8B" },
+    "passes": {
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp32" },
+        "int4_quantize": {
+            "type": "OnnxKQuantQuantization",
+            "bits": 4,
+            "block_size": 32,
+            "save_as_external_data": true
+        }
+    },
+    "output_dir": "cpu/int4/models"
+}

--- a/tencent-Hy-MT2-1.8B/cpu/int4_tie/config.json
+++ b/tencent-Hy-MT2-1.8B/cpu/int4_tie/config.json
@@ -1,0 +1,29 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "tencent/Hy-MT2-1.8B" },
+    "passes": {
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp32" },
+        "kquant_body": {
+            "type": "OnnxKQuantQuantization",
+            "bits": 4,
+            "block_size": 32,
+            "save_as_external_data": true
+        },
+        "rtn_embed": {
+            "type": "OnnxBlockWiseRtnQuantization",
+            "bits": 4,
+            "block_size": 32,
+            "is_symmetric": false,
+            "save_as_external_data": true
+        },
+        "tie_embeddings": {
+            "type": "GraphSurgeries",
+            "surgeries": [ { "surgeon": "TieWordEmbeddings" } ],
+            "save_as_external_data": true
+        }
+    },
+    "target": {
+        "type": "LocalSystem",
+        "accelerators": [{ "device": "cpu", "execution_providers": ["CPUExecutionProvider"] }]
+    },
+    "output_dir": "cpu/int4_tie/models"
+}

--- a/tencent-Hy-MT2-1.8B/cuda/bf16/config.json
+++ b/tencent-Hy-MT2-1.8B/cuda/bf16/config.json
@@ -1,0 +1,11 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "tencent/Hy-MT2-1.8B" },
+    "passes": {
+        "mobius_build": { "type": "MobiusBuilder", "precision": "bf16" }
+    },
+    "target": {
+        "type": "LocalSystem",
+        "accelerators": [{ "device": "gpu", "execution_providers": ["CUDAExecutionProvider"] }]
+    },
+    "output_dir": "cuda/bf16/models"
+}

--- a/tencent-Hy-MT2-1.8B/cuda/fp16/config.json
+++ b/tencent-Hy-MT2-1.8B/cuda/fp16/config.json
@@ -1,0 +1,11 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "tencent/Hy-MT2-1.8B" },
+    "passes": {
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp16" }
+    },
+    "target": {
+        "type": "LocalSystem",
+        "accelerators": [{ "device": "gpu", "execution_providers": ["CUDAExecutionProvider"] }]
+    },
+    "output_dir": "cuda/fp16/models"
+}

--- a/tencent-Hy-MT2-1.8B/cuda/int4/config.json
+++ b/tencent-Hy-MT2-1.8B/cuda/int4/config.json
@@ -1,13 +1,29 @@
 {
-    "input_model": { "type": "HfModel", "model_path": "tencent/Hy-MT2-1.8B" },
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "tencent/Hy-MT2-1.8B",
+        "load_kwargs": { "torch_dtype": "float16" }
+    },
     "passes": {
-        "mobius_build": { "type": "MobiusBuilder", "precision": "fp16" },
-        "int4_quantize": {
-            "type": "OnnxKQuantQuantization",
+        "gptq_quantize": {
+            "type": "gptq",
             "bits": 4,
-            "block_size": 32,
-            "save_as_external_data": true
-        }
+            "sym": false,
+            "group_size": 32
+        },
+        "rtn_quantize": {
+            "type": "rtn",
+            "bits": 4,
+            "sym": false,
+            "group_size": 32,
+            "lm_head": true,
+            "embeds": true,
+            "overrides": {
+                "lm_head": { "bits": 4 },
+                "model.embed_tokens": { "bits": 4 }
+            }
+        },
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp16" }
     },
     "target": {
         "type": "LocalSystem",

--- a/tencent-Hy-MT2-1.8B/cuda/int4/config.json
+++ b/tencent-Hy-MT2-1.8B/cuda/int4/config.json
@@ -1,0 +1,17 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "tencent/Hy-MT2-1.8B" },
+    "passes": {
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp16" },
+        "int4_quantize": {
+            "type": "OnnxKQuantQuantization",
+            "bits": 4,
+            "block_size": 32,
+            "save_as_external_data": true
+        }
+    },
+    "target": {
+        "type": "LocalSystem",
+        "accelerators": [{ "device": "gpu", "execution_providers": ["CUDAExecutionProvider"] }]
+    },
+    "output_dir": "cuda/int4/models"
+}

--- a/tencent-Hy-MT2-1.8B/cuda/int4/config.json
+++ b/tencent-Hy-MT2-1.8B/cuda/int4/config.json
@@ -1,29 +1,25 @@
 {
-    "input_model": {
-        "type": "HfModel",
-        "model_path": "tencent/Hy-MT2-1.8B",
-        "load_kwargs": { "torch_dtype": "float16" }
-    },
+    "input_model": { "type": "HfModel", "model_path": "tencent/Hy-MT2-1.8B" },
     "passes": {
-        "gptq_quantize": {
-            "type": "gptq",
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp16" },
+        "kquant_body": {
+            "type": "OnnxKQuantQuantization",
             "bits": 4,
-            "sym": false,
-            "group_size": 32
+            "block_size": 32,
+            "save_as_external_data": true
         },
-        "rtn_quantize": {
-            "type": "rtn",
+        "rtn_embed": {
+            "type": "OnnxBlockWiseRtnQuantization",
             "bits": 4,
-            "sym": false,
-            "group_size": 32,
-            "lm_head": true,
-            "embeds": true,
-            "overrides": {
-                "lm_head": { "bits": 4 },
-                "model.embed_tokens": { "bits": 4 }
-            }
+            "block_size": 32,
+            "is_symmetric": false,
+            "save_as_external_data": true
         },
-        "mobius_build": { "type": "MobiusBuilder", "precision": "fp16" }
+        "tie_embeddings": {
+            "type": "GraphSurgeries",
+            "surgeries": [ { "surgeon": "TieWordEmbeddings" } ],
+            "save_as_external_data": true
+        }
     },
     "target": {
         "type": "LocalSystem",

--- a/tencent-Hy-MT2-1.8B/cuda/int4_gptq/config.json
+++ b/tencent-Hy-MT2-1.8B/cuda/int4_gptq/config.json
@@ -1,0 +1,33 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "tencent/Hy-MT2-1.8B",
+        "load_kwargs": { "torch_dtype": "float16" }
+    },
+    "passes": {
+        "gptq_quantize": {
+            "type": "gptq",
+            "bits": 4,
+            "sym": false,
+            "group_size": 32
+        },
+        "rtn_quantize": {
+            "type": "rtn",
+            "bits": 4,
+            "sym": false,
+            "group_size": 32,
+            "lm_head": true,
+            "embeds": true,
+            "overrides": {
+                "lm_head": { "bits": 4 },
+                "model.embed_tokens": { "bits": 4 }
+            }
+        },
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp16" }
+    },
+    "target": {
+        "type": "LocalSystem",
+        "accelerators": [{ "device": "gpu", "execution_providers": ["CUDAExecutionProvider"] }]
+    },
+    "output_dir": "cuda/int4_gptq/models"
+}

--- a/tencent-Hy-MT2-1.8B/inference.py
+++ b/tencent-Hy-MT2-1.8B/inference.py
@@ -1,0 +1,137 @@
+# ruff: noqa: RUF001, RUF002
+"""ONNX Runtime GenAI translation inference for Tencent Hy-MT2-1.8B.
+
+Hy-MT2 is a multilingual (33-language) translation model. This script loads
+a mobius-exported ONNX package (fp32 / fp16 / bf16 / int4) and translates a
+source text into a target language using greedy decoding.
+
+Tokenizer note: the Hy-MT BPE vocab uses a custom regex pre-tokenizer that
+ort-extensions does not currently round-trip, so by default we tokenize and
+detokenize with the HuggingFace tokenizer and feed raw token IDs to
+``og.Generator`` (this still exercises the full ORT GenAI inference path).
+Pass ``--use-ort-tokenizer`` to force the ``og.Tokenizer`` path.
+
+Usage:
+    python inference.py --source "今天天气真好。" --target-lang English
+    python inference.py --device gpu --variant int4 --source "Hello world" \
+        --target-lang Chinese
+    python inference.py --device gpu --variant bf16 --interactive
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import onnxruntime_genai as og
+
+HF_MODEL_ID = "tencent/Hy-MT2-1.8B"
+# <｜hy_place▁holder▁no▁2｜>, the turn-end / EOS from generation_config.
+EOS_TOKEN_ID = 120020
+
+_RECIPE_DIR = Path(__file__).resolve().parent
+
+
+def resolve_model_path(device: str, variant: str | None) -> str:
+    """Resolve the model directory from device + variant args."""
+    if device == "cpu":
+        variant = variant or "fp32"
+        return str(_RECIPE_DIR / "cpu" / variant / "models")
+    variant = variant or "int4"
+    return str(_RECIPE_DIR / "cuda" / variant / "models")
+
+
+def format_prompt(tokenizer, source: str, target_lang: str) -> str:
+    """Apply the Hy-MT chat template to a translation instruction."""
+    instruction = (
+        f"Translate the following text into {target_lang}. Note that you "
+        f"should only output the translated result without any additional "
+        f"explanation:\n\n{source}"
+    )
+    return tokenizer.apply_chat_template(
+        [{"role": "user", "content": instruction}],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+
+def translate(
+    model: og.Model,
+    hf_tokenizer,
+    source: str,
+    target_lang: str,
+    max_new_tokens: int,
+) -> str:
+    """Greedy-decode a single translation via the HF tokenizer + ORT GenAI."""
+    prompt = format_prompt(hf_tokenizer, source, target_lang)
+    input_tokens = hf_tokenizer.encode(prompt, add_special_tokens=False)
+
+    params = og.GeneratorParams(model)
+    params.set_search_options(max_length=len(input_tokens) + max_new_tokens, do_sample=False)
+    generator = og.Generator(model, params)
+    generator.append_tokens(input_tokens)
+
+    generated: list[int] = []
+    while not generator.is_done() and len(generated) < max_new_tokens:
+        generator.generate_next_token()
+        token = int(generator.get_next_tokens()[0])
+        if token == EOS_TOKEN_ID:
+            break
+        generated.append(token)
+    return hf_tokenizer.decode(generated, skip_special_tokens=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", choices=("cpu", "gpu"), default="cpu")
+    parser.add_argument(
+        "--variant",
+        choices=("fp32", "fp16", "bf16", "int4"),
+        default=None,
+        help="Precision variant. Defaults to fp32 (cpu) / int4 (gpu).",
+    )
+    parser.add_argument("--model-path", default=None, help="Override the model directory.")
+    parser.add_argument("--source", default="黄河之水天上来", help="Text to translate.")
+    parser.add_argument("--target-lang", default="English", help="Target language name.")
+    parser.add_argument("--max-new-tokens", type=int, default=256)
+    parser.add_argument("--interactive", action="store_true")
+    args = parser.parse_args()
+
+    model_path = args.model_path or resolve_model_path(args.device, args.variant)
+    if not (Path(model_path) / "genai_config.json").exists():
+        raise SystemExit(
+            f"No genai_config.json in {model_path}. Build the recipe first, e.g.\n"
+            f"  olive run --config {args.device}/"
+            f"{args.variant or ('fp32' if args.device == 'cpu' else 'int4')}/config.json"
+        )
+
+    print(f"Loading ORT GenAI model from {model_path}")
+    model = og.Model(model_path)
+
+    import transformers
+
+    hf_tokenizer = transformers.AutoTokenizer.from_pretrained(HF_MODEL_ID)
+
+    if args.interactive:
+        print("Interactive translation. Ctrl-C to exit.")
+        print(f"Target language: {args.target_lang}\n")
+        try:
+            while True:
+                source = input("source> ").strip()
+                if not source:
+                    continue
+                out = translate(
+                    model, hf_tokenizer, source, args.target_lang, args.max_new_tokens
+                )
+                print(f"  {out}\n")
+        except (KeyboardInterrupt, EOFError):
+            print("\nBye.")
+        return
+
+    out = translate(model, hf_tokenizer, args.source, args.target_lang, args.max_new_tokens)
+    print(f"\nsource ({args.target_lang}): {args.source}")
+    print(f"translation: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tencent-Hy-MT2-1.8B/info.yml
+++ b/tencent-Hy-MT2-1.8B/info.yml
@@ -13,6 +13,7 @@ arch: hunyuan
 ep:
   - CPUExecutionProvider
   - CUDAExecutionProvider
+  - WebGpuExecutionProvider
 device:
   - cpu
   - gpu
@@ -38,6 +39,11 @@ recipes:
     devices:
       - cpu
     eps: CPUExecutionProvider
+  - name: hy-mt2-1_8b-int4-kquant-tie-cpu
+    file: cpu/int4_tie/config.json
+    devices:
+      - cpu
+    eps: CPUExecutionProvider
   - name: hy-mt2-1_8b-fp16-cuda
     file: cuda/fp16/config.json
     devices:
@@ -58,3 +64,8 @@ recipes:
     devices:
       - gpu
     eps: CUDAExecutionProvider
+  - name: hy-mt2-1_8b-int4-kquant-tie-webgpu
+    file: webgpu/int4_tie/config.json
+    devices:
+      - gpu
+    eps: WebGpuExecutionProvider

--- a/tencent-Hy-MT2-1.8B/info.yml
+++ b/tencent-Hy-MT2-1.8B/info.yml
@@ -6,7 +6,6 @@ keywords:
   - multilingual
   - int4
   - kquant
-  - gptq
   - rtn
   - mobius
 arch: hunyuan
@@ -48,7 +47,7 @@ recipes:
     devices:
       - gpu
     eps: CUDAExecutionProvider
-  - name: hy-mt2-1_8b-int4-gptq-cuda
+  - name: hy-mt2-1_8b-int4-kquant-cuda
     file: cuda/int4/config.json
     devices:
       - gpu

--- a/tencent-Hy-MT2-1.8B/info.yml
+++ b/tencent-Hy-MT2-1.8B/info.yml
@@ -21,6 +21,16 @@ recipes:
     devices:
       - cpu
     eps: CPUExecutionProvider
+  - name: hy-mt2-1_8b-fp16-cpu
+    file: cpu/fp16/config.json
+    devices:
+      - cpu
+    eps: CPUExecutionProvider
+  - name: hy-mt2-1_8b-bf16-cpu
+    file: cpu/bf16/config.json
+    devices:
+      - cpu
+    eps: CPUExecutionProvider
   - name: hy-mt2-1_8b-int4-kquant-cpu
     file: cpu/int4/config.json
     devices:

--- a/tencent-Hy-MT2-1.8B/info.yml
+++ b/tencent-Hy-MT2-1.8B/info.yml
@@ -1,0 +1,43 @@
+keywords:
+  - hunyuan
+  - hunyuan-v1-dense
+  - hy-mt2
+  - translation
+  - multilingual
+  - int4
+  - kquant
+  - mobius
+arch: hunyuan
+ep:
+  - CPUExecutionProvider
+  - CUDAExecutionProvider
+device:
+  - cpu
+  - gpu
+name: hy_mt2_1_8b
+recipes:
+  - name: hy-mt2-1_8b-fp32-cpu
+    file: cpu/fp32/config.json
+    devices:
+      - cpu
+    eps: CPUExecutionProvider
+  - name: hy-mt2-1_8b-int4-kquant-cpu
+    file: cpu/int4/config.json
+    devices:
+      - cpu
+    eps: CPUExecutionProvider
+  - name: hy-mt2-1_8b-fp16-cuda
+    file: cuda/fp16/config.json
+    devices:
+      - gpu
+    eps: CUDAExecutionProvider
+  - name: hy-mt2-1_8b-bf16-cuda
+    file: cuda/bf16/config.json
+    devices:
+      - gpu
+    eps: CUDAExecutionProvider
+  - name: hy-mt2-1_8b-int4-kquant-cuda
+    file: cuda/int4/config.json
+    devices:
+      - gpu
+    eps: CUDAExecutionProvider

--- a/tencent-Hy-MT2-1.8B/info.yml
+++ b/tencent-Hy-MT2-1.8B/info.yml
@@ -7,6 +7,7 @@ keywords:
   - int4
   - kquant
   - rtn
+  - gptq
   - mobius
 arch: hunyuan
 ep:
@@ -49,6 +50,11 @@ recipes:
     eps: CUDAExecutionProvider
   - name: hy-mt2-1_8b-int4-kquant-cuda
     file: cuda/int4/config.json
+    devices:
+      - gpu
+    eps: CUDAExecutionProvider
+  - name: hy-mt2-1_8b-int4-gptq-cuda
+    file: cuda/int4_gptq/config.json
     devices:
       - gpu
     eps: CUDAExecutionProvider

--- a/tencent-Hy-MT2-1.8B/info.yml
+++ b/tencent-Hy-MT2-1.8B/info.yml
@@ -6,6 +6,8 @@ keywords:
   - multilingual
   - int4
   - kquant
+  - gptq
+  - rtn
   - mobius
 arch: hunyuan
 ep:
@@ -46,7 +48,7 @@ recipes:
     devices:
       - gpu
     eps: CUDAExecutionProvider
-  - name: hy-mt2-1_8b-int4-kquant-cuda
+  - name: hy-mt2-1_8b-int4-gptq-cuda
     file: cuda/int4/config.json
     devices:
       - gpu

--- a/tencent-Hy-MT2-1.8B/requirements.txt
+++ b/tencent-Hy-MT2-1.8B/requirements.txt
@@ -1,0 +1,3 @@
+lm-eval
+mobius-ai
+olive-ai[gpu]

--- a/tencent-Hy-MT2-1.8B/requirements.txt
+++ b/tencent-Hy-MT2-1.8B/requirements.txt
@@ -1,3 +1,4 @@
 lm-eval
 mobius-ai
 olive-ai[gpu]
+gptqmodel

--- a/tencent-Hy-MT2-1.8B/requirements.txt
+++ b/tencent-Hy-MT2-1.8B/requirements.txt
@@ -1,4 +1,3 @@
 lm-eval
 mobius-ai
 olive-ai[gpu]
-gptqmodel

--- a/tencent-Hy-MT2-1.8B/webgpu/int4_tie/config.json
+++ b/tencent-Hy-MT2-1.8B/webgpu/int4_tie/config.json
@@ -1,0 +1,29 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "tencent/Hy-MT2-1.8B" },
+    "passes": {
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp16" },
+        "kquant_body": {
+            "type": "OnnxKQuantQuantization",
+            "bits": 4,
+            "block_size": 32,
+            "save_as_external_data": true
+        },
+        "rtn_embed": {
+            "type": "OnnxBlockWiseRtnQuantization",
+            "bits": 4,
+            "block_size": 32,
+            "is_symmetric": false,
+            "save_as_external_data": true
+        },
+        "tie_embeddings": {
+            "type": "GraphSurgeries",
+            "surgeries": [ { "surgeon": "TieWordEmbeddings" } ],
+            "save_as_external_data": true
+        }
+    },
+    "target": {
+        "type": "LocalSystem",
+        "accelerators": [{ "device": "gpu", "execution_providers": ["WebGpuExecutionProvider"] }]
+    },
+    "output_dir": "webgpu/int4_tie/models"
+}


### PR DESCRIPTION
## Description

Adds Olive recipes that export [tencent/Hy-MT2-1.8B](https://huggingface.co/tencent/Hy-MT2-1.8B) — a fast multilingual (33-language) translation model — to ONNX via the `MobiusBuilder` pass, with optional INT4 K-Quant (Q4_K_M) quantization.

### Recipes

| Recipe | Pipeline |
|---|---|
| `cpu/fp32` | MobiusBuilder(fp32) |
| `cpu/int4` | MobiusBuilder(fp32) → OnnxKQuantQuantization(bits=4, block_size=32) |
| `cuda/fp16` | MobiusBuilder(fp16) |
| `cuda/bf16` | MobiusBuilder(bf16) |
| `cuda/int4` | MobiusBuilder(fp16) → OnnxKQuantQuantization(bits=4, block_size=32) |

### Validation

- All 5 recipes build successfully with `olive run`.
- CPU INT4 and CUDA INT4 packages produce correct translations via ORT GenAI (e.g. `黄河之水天上来` → "The water of the Yellow River comes from the sky").
- The underlying mobius ONNX export is verified token-for-token against HuggingFace `transformers` (greedy prefill + generation goldens) in the mobius repo.

### Contents

`info.yml`, 5 `config.json` recipes, `inference.py` (ORT GenAI; uses the HF tokenizer to round-trip the custom Hy-MT BPE vocab), `requirements.txt`, `README.md`, `LICENSE`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>