### PR TITLE
[experimental] Add QNN (Snapdragon NPU) recipes for Gemma 4 E2B

### DIFF
--- a/google-gemma-4-E2B-it/.gitignore
+++ b/google-gemma-4-E2B-it/.gitignore
@@ -3,6 +3,7 @@ models/
 cpu/models/
 cuda/*/models/
 openvino/*/models/
+qnn/*/models/
 
 # Python bytecode
 __pycache__/

--- a/google-gemma-4-E2B-it/.gitignore
+++ b/google-gemma-4-E2B-it/.gitignore
@@ -5,6 +5,12 @@ cuda/*/models/
 openvino/*/models/
 qnn/*/models/
 
+# The repo-root .gitignore ignores 'build/' (Python build artifacts); the QNN
+# step-1 build recipe lives under qnn/build/, so re-include it here (its model
+# output under qnn/build/models/ stays ignored).
+!qnn/build/
+qnn/build/models/
+
 # Python bytecode
 __pycache__/
 *.pyc

--- a/google-gemma-4-E2B-it/README.md
+++ b/google-gemma-4-E2B-it/README.md
@@ -115,6 +115,52 @@ python eval.py
 python eval.py --device gpu --variant int4
 ```
 
+## QNN (Snapdragon NPU) — experimental, two-step
+
+> **Status: untested.** These configs are authored from the Olive QNN/HTP
+> reference flow. Building an HTP context binary requires the **QNN SDK
+> (via `onnxruntime-qnn`) and a Snapdragon target** — it cannot run on a
+> generic x86/CUDA host. The mobius build and the decoder `GraphSurgeries`
+> step were validated on CPU; every QNN-specific step below is **not yet
+> verified on hardware**.
+
+Because the QNN/HTP LLM passes (`SplitModel`, `StaticLLM`,
+`EPContextBinaryGenerator`) operate on a single decoder — and mobius emits a
+multi-component package — the QNN path is a **two-step** flow that compiles
+each component separately:
+
+```bash
+# Step 1 — build the portable (onnx-standard) multi-component model
+olive run --config qnn/build/config.json
+
+# Step 2 — compile each component to an HTP context binary
+#   (run in a Python env that has onnxruntime-qnn installed; set
+#    python_environment_path and soc_model for your Snapdragon target)
+olive run --config qnn/decoder/config.json          # text decoder (full HTP LLM flow)
+olive run --config qnn/vision_encoder/config.json   # vision encoder
+olive run --config qnn/audio_encoder/config.json    # audio encoder
+olive run --config qnn/embedding/config.json        # embedding fusion
+```
+
+| Recipe | Component | Pipeline |
+|---|---|---|
+| `qnn/build/config.json` | all | `MobiusBuilder(fp32, onnx-standard)` → decoder + vision + audio + embedding |
+| `qnn/decoder/config.json` | decoder | `GraphSurgeries` → `OnnxStaticQuantization` → `SplitModel` → `StaticLLM` → `EPContextBinaryGenerator` → `ComposeOnnxModels` |
+| `qnn/{vision_encoder,audio_encoder,embedding}/config.json` | encoders | `EPContextBinaryGenerator(enable_htp_fp16_precision)` → `ComposeOnnxModels` |
+
+Notes / TODOs before hardware bring-up:
+- Set `systems.qnn_system.python_environment_path` to a venv with
+  `onnxruntime-qnn` installed, and set `cb.provider_options.soc_model` to your
+  device's SoC id.
+- The decoder uses `wikitext` for activation calibration; adjust
+  `context_length` / `batch_size` in `StaticLLM` for your latency budget.
+- Only `AttentionMaskToSequenceLengths` and `SimplifiedLayerNormToL2Norm`
+  surgeries apply to the mobius decoder — the ModelBuilder-specific
+  `RemoveRopeMultiCache` surgery is intentionally omitted (it does not match
+  mobius's single-`RotaryEmbedding` structure).
+- Encoders compile via HTP fp16; per-modality static quantization can be added
+  later with representative image/audio calibration data.
+
 ## References
 
 - Mobius docs: <https://github.com/onnxruntime/mobius>

--- a/google-gemma-4-E2B-it/README.md
+++ b/google-gemma-4-E2B-it/README.md
@@ -117,12 +117,14 @@ python eval.py --device gpu --variant int4
 
 ## QNN (Snapdragon NPU) — experimental, two-step
 
-> **Status: untested.** These configs are authored from the Olive QNN/HTP
-> reference flow. Building an HTP context binary requires the **QNN SDK
+> **Status: untested on hardware.** These configs are authored from the Olive
+> QNN/HTP reference flow. Building an HTP context binary requires the **QNN SDK
 > (via `onnxruntime-qnn`) and a Snapdragon target** — it cannot run on a
-> generic x86/CUDA host. The mobius build and the decoder `GraphSurgeries`
-> step were validated on CPU; every QNN-specific step below is **not yet
-> verified on hardware**.
+> generic x86/CUDA host. Validated on CPU: the mobius build, K-Quant, the
+> `MatMulNBitsToQDQ` INT4-QDQ lowering (produces zero `com.microsoft` ops), and
+> the decoder `GraphSurgeries`. The HTP-specific steps
+> (`OnnxStaticQuantization` for HTP, `SplitModel`, `StaticLLM`,
+> `EPContextBinaryGenerator`) are **not yet verified on hardware**.
 
 Because the QNN/HTP LLM passes (`SplitModel`, `StaticLLM`,
 `EPContextBinaryGenerator`) operate on a single decoder — and mobius emits a
@@ -144,22 +146,24 @@ olive run --config qnn/embedding/config.json        # embedding fusion
 
 | Recipe | Component | Pipeline |
 |---|---|---|
-| `qnn/build/config.json` | all | `MobiusBuilder(fp32, onnx-standard)` → decoder + vision + audio + embedding |
-| `qnn/decoder/config.json` | decoder | `GraphSurgeries` → `OnnxStaticQuantization` → `SplitModel` → `StaticLLM` → `EPContextBinaryGenerator` → `ComposeOnnxModels` |
-| `qnn/{vision_encoder,audio_encoder,embedding}/config.json` | encoders | `EPContextBinaryGenerator(enable_htp_fp16_precision)` → `ComposeOnnxModels` |
+| `qnn/build/config.json` | all | `MobiusBuilder(fp32, onnx-standard)` → `OnnxKQuantQuantization(int4)` → decoder + vision + audio + embedding |
+| `qnn/decoder/config.json` | decoder | `MatMulNBitsToQDQ` → `GraphSurgeries` → `OnnxStaticQuantization` → `SplitModel` → `StaticLLM` → `EPContextBinaryGenerator` → `ComposeOnnxModels` |
+| `qnn/{vision_encoder,audio_encoder,embedding}/config.json` | encoders | `MatMulNBitsToQDQ` → `EPContextBinaryGenerator(enable_htp_fp16_precision)` → `ComposeOnnxModels` |
 
 Notes / TODOs before hardware bring-up:
 - Set `systems.qnn_system.python_environment_path` to a venv with
   `onnxruntime-qnn` installed, and set `cb.provider_options.soc_model` to your
   device's SoC id.
-- The decoder uses `wikitext` for activation calibration; adjust
-  `context_length` / `batch_size` in `StaticLLM` for your latency budget.
+- The build step quantizes weights to INT4 with K-Quant; `MatMulNBitsToQDQ`
+  then lowers the `MatMulNBits` ops to **standard-ONNX INT4 QDQ**
+  (`DequantizeLinear` + `MatMul`, zero `com.microsoft` ops), which the QNN HTP
+  backend can consume. The decoder additionally static-quantizes activations
+  (`wikitext` calibration); the encoders keep FP16 activations on HTP.
+- Adjust `context_length` / `batch_size` in `StaticLLM` for your latency budget.
 - Only `AttentionMaskToSequenceLengths` and `SimplifiedLayerNormToL2Norm`
   surgeries apply to the mobius decoder — the ModelBuilder-specific
   `RemoveRopeMultiCache` surgery is intentionally omitted (it does not match
   mobius's single-`RotaryEmbedding` structure).
-- Encoders compile via HTP fp16; per-modality static quantization can be added
-  later with representative image/audio calibration data.
 
 ## References
 

--- a/google-gemma-4-E2B-it/info.yml
+++ b/google-gemma-4-E2B-it/info.yml
@@ -6,11 +6,13 @@ keywords:
   - kquant
   - mobius
   - openvino
+  - qnn
 arch: gemma
 ep:
   - CPUExecutionProvider
   - CUDAExecutionProvider
   - OpenVINOExecutionProvider
+  - QNNExecutionProvider
 device:
   - cpu
   - gpu
@@ -47,3 +49,28 @@ recipes:
     devices:
       - gpu
     eps: OpenVINOExecutionProvider
+  - name: gemma4-e2b-qnn-build
+    file: qnn/build/config.json
+    devices:
+      - npu
+    eps: QNNExecutionProvider
+  - name: gemma4-e2b-qnn-decoder
+    file: qnn/decoder/config.json
+    devices:
+      - npu
+    eps: QNNExecutionProvider
+  - name: gemma4-e2b-qnn-vision-encoder
+    file: qnn/vision_encoder/config.json
+    devices:
+      - npu
+    eps: QNNExecutionProvider
+  - name: gemma4-e2b-qnn-audio-encoder
+    file: qnn/audio_encoder/config.json
+    devices:
+      - npu
+    eps: QNNExecutionProvider
+  - name: gemma4-e2b-qnn-embedding
+    file: qnn/embedding/config.json
+    devices:
+      - npu
+    eps: QNNExecutionProvider

--- a/google-gemma-4-E2B-it/qnn/audio_encoder/config.json
+++ b/google-gemma-4-E2B-it/qnn/audio_encoder/config.json
@@ -10,12 +10,20 @@
             "accelerators": [
                 {
                     "device": "npu",
-                    "execution_providers": ["QNNExecutionProvider"]
+                    "execution_providers": [
+                        "QNNExecutionProvider"
+                    ]
                 }
             ]
         }
     },
     "passes": {
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": true,
+            "save_as_external_data": true
+        },
         "cb": {
             "type": "EPContextBinaryGenerator",
             "provider_options": {
@@ -26,7 +34,9 @@
             },
             "weight_sharing": true
         },
-        "cp": { "type": "ComposeOnnxModels" }
+        "cp": {
+            "type": "ComposeOnnxModels"
+        }
     },
     "target": "qnn_system",
     "log_severity_level": 1,

--- a/google-gemma-4-E2B-it/qnn/audio_encoder/config.json
+++ b/google-gemma-4-E2B-it/qnn/audio_encoder/config.json
@@ -1,0 +1,37 @@
+{
+    "input_model": {
+        "type": "OnnxModel",
+        "model_path": "qnn/build/models/audio_encoder/model.onnx"
+    },
+    "systems": {
+        "qnn_system": {
+            "type": "PythonEnvironment",
+            "python_environment_path": "/path/to/qnn/env/bin",
+            "accelerators": [
+                {
+                    "device": "npu",
+                    "execution_providers": ["QNNExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "cb": {
+            "type": "EPContextBinaryGenerator",
+            "provider_options": {
+                "htp_performance_mode": "burst",
+                "htp_graph_finalization_optimization_mode": "3",
+                "enable_htp_fp16_precision": "1",
+                "soc_model": "60"
+            },
+            "weight_sharing": true
+        },
+        "cp": { "type": "ComposeOnnxModels" }
+    },
+    "target": "qnn_system",
+    "log_severity_level": 1,
+    "output_dir": "qnn/audio_encoder/models",
+    "cache_dir": "cache",
+    "no_artifacts": false,
+    "evaluate_input_model": false
+}

--- a/google-gemma-4-E2B-it/qnn/build/config.json
+++ b/google-gemma-4-E2B-it/qnn/build/config.json
@@ -1,0 +1,11 @@
+{
+    "input_model": { "type": "HfModel", "model_path": "google/gemma-4-E2B-it" },
+    "passes": {
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp32" }
+    },
+    "target": {
+        "type": "LocalSystem",
+        "accelerators": [{ "device": "npu", "execution_providers": ["QNNExecutionProvider"] }]
+    },
+    "output_dir": "qnn/build/models"
+}

--- a/google-gemma-4-E2B-it/qnn/build/config.json
+++ b/google-gemma-4-E2B-it/qnn/build/config.json
@@ -1,7 +1,13 @@
 {
     "input_model": { "type": "HfModel", "model_path": "google/gemma-4-E2B-it" },
     "passes": {
-        "mobius_build": { "type": "MobiusBuilder", "precision": "fp32" }
+        "mobius_build": { "type": "MobiusBuilder", "precision": "fp32" },
+        "int4_quantize": {
+            "type": "OnnxKQuantQuantization",
+            "bits": 4,
+            "block_size": 32,
+            "save_as_external_data": true
+        }
     },
     "target": {
         "type": "LocalSystem",

--- a/google-gemma-4-E2B-it/qnn/decoder/config.json
+++ b/google-gemma-4-E2B-it/qnn/decoder/config.json
@@ -1,0 +1,76 @@
+{
+    "input_model": {
+        "type": "OnnxModel",
+        "model_path": "qnn/build/models/decoder/model.onnx"
+    },
+    "systems": {
+        "qnn_system": {
+            "type": "PythonEnvironment",
+            "python_environment_path": "/path/to/qnn/env/bin",
+            "accelerators": [
+                {
+                    "device": "npu",
+                    "execution_providers": ["QNNExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "data_configs": [
+        {
+            "name": "wikitext2_train_act",
+            "type": "HuggingfaceContainer",
+            "load_dataset_config": {
+                "data_name": "wikitext",
+                "subset": "wikitext-2-raw-v1",
+                "split": "train"
+            },
+            "pre_process_data_config": {
+                "strategy": "line-by-line",
+                "add_special_tokens": true,
+                "max_samples": 256,
+                "max_seq_len": 1024
+            }
+        }
+    ],
+    "passes": {
+        "gs": {
+            "type": "GraphSurgeries",
+            "surgeries": [
+                { "surgeon": "AttentionMaskToSequenceLengths" },
+                { "surgeon": "SimplifiedLayerNormToL2Norm" }
+            ],
+            "save_as_external_data": true
+        },
+        "sq": {
+            "type": "OnnxStaticQuantization",
+            "data_config": "wikitext2_train_act",
+            "activation_type": "uint16",
+            "precision": "uint8",
+            "calibration_providers": ["CPUExecutionProvider"],
+            "quant_preprocess": true,
+            "save_as_external_data": true
+        },
+        "sp": { "type": "SplitModel" },
+        "st": {
+            "type": "StaticLLM",
+            "batch_size": 1,
+            "context_length": 64
+        },
+        "cb": {
+            "type": "EPContextBinaryGenerator",
+            "provider_options": {
+                "htp_performance_mode": "burst",
+                "htp_graph_finalization_optimization_mode": "3",
+                "soc_model": "60"
+            },
+            "weight_sharing": true
+        },
+        "cp": { "type": "ComposeOnnxModels" }
+    },
+    "target": "qnn_system",
+    "log_severity_level": 1,
+    "output_dir": "qnn/decoder/models",
+    "cache_dir": "cache",
+    "no_artifacts": false,
+    "evaluate_input_model": false
+}

--- a/google-gemma-4-E2B-it/qnn/decoder/config.json
+++ b/google-gemma-4-E2B-it/qnn/decoder/config.json
@@ -33,6 +33,12 @@
         }
     ],
     "passes": {
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": true,
+            "save_as_external_data": true
+        },
         "gs": {
             "type": "GraphSurgeries",
             "surgeries": [
@@ -48,6 +54,7 @@
             "precision": "uint8",
             "calibration_providers": ["CPUExecutionProvider"],
             "quant_preprocess": true,
+            "op_types_to_exclude": ["DequantizeLinear", "QuantizeLinear"],
             "save_as_external_data": true
         },
         "sp": { "type": "SplitModel" },

--- a/google-gemma-4-E2B-it/qnn/embedding/config.json
+++ b/google-gemma-4-E2B-it/qnn/embedding/config.json
@@ -10,12 +10,20 @@
             "accelerators": [
                 {
                     "device": "npu",
-                    "execution_providers": ["QNNExecutionProvider"]
+                    "execution_providers": [
+                        "QNNExecutionProvider"
+                    ]
                 }
             ]
         }
     },
     "passes": {
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": true,
+            "save_as_external_data": true
+        },
         "cb": {
             "type": "EPContextBinaryGenerator",
             "provider_options": {
@@ -26,7 +34,9 @@
             },
             "weight_sharing": true
         },
-        "cp": { "type": "ComposeOnnxModels" }
+        "cp": {
+            "type": "ComposeOnnxModels"
+        }
     },
     "target": "qnn_system",
     "log_severity_level": 1,

--- a/google-gemma-4-E2B-it/qnn/embedding/config.json
+++ b/google-gemma-4-E2B-it/qnn/embedding/config.json
@@ -1,0 +1,37 @@
+{
+    "input_model": {
+        "type": "OnnxModel",
+        "model_path": "qnn/build/models/embedding/model.onnx"
+    },
+    "systems": {
+        "qnn_system": {
+            "type": "PythonEnvironment",
+            "python_environment_path": "/path/to/qnn/env/bin",
+            "accelerators": [
+                {
+                    "device": "npu",
+                    "execution_providers": ["QNNExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "cb": {
+            "type": "EPContextBinaryGenerator",
+            "provider_options": {
+                "htp_performance_mode": "burst",
+                "htp_graph_finalization_optimization_mode": "3",
+                "enable_htp_fp16_precision": "1",
+                "soc_model": "60"
+            },
+            "weight_sharing": true
+        },
+        "cp": { "type": "ComposeOnnxModels" }
+    },
+    "target": "qnn_system",
+    "log_severity_level": 1,
+    "output_dir": "qnn/embedding/models",
+    "cache_dir": "cache",
+    "no_artifacts": false,
+    "evaluate_input_model": false
+}

--- a/google-gemma-4-E2B-it/qnn/vision_encoder/config.json
+++ b/google-gemma-4-E2B-it/qnn/vision_encoder/config.json
@@ -1,0 +1,37 @@
+{
+    "input_model": {
+        "type": "OnnxModel",
+        "model_path": "qnn/build/models/vision_encoder/model.onnx"
+    },
+    "systems": {
+        "qnn_system": {
+            "type": "PythonEnvironment",
+            "python_environment_path": "/path/to/qnn/env/bin",
+            "accelerators": [
+                {
+                    "device": "npu",
+                    "execution_providers": ["QNNExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "passes": {
+        "cb": {
+            "type": "EPContextBinaryGenerator",
+            "provider_options": {
+                "htp_performance_mode": "burst",
+                "htp_graph_finalization_optimization_mode": "3",
+                "enable_htp_fp16_precision": "1",
+                "soc_model": "60"
+            },
+            "weight_sharing": true
+        },
+        "cp": { "type": "ComposeOnnxModels" }
+    },
+    "target": "qnn_system",
+    "log_severity_level": 1,
+    "output_dir": "qnn/vision_encoder/models",
+    "cache_dir": "cache",
+    "no_artifacts": false,
+    "evaluate_input_model": false
+}

--- a/google-gemma-4-E2B-it/qnn/vision_encoder/config.json
+++ b/google-gemma-4-E2B-it/qnn/vision_encoder/config.json
@@ -10,12 +10,20 @@
             "accelerators": [
                 {
                     "device": "npu",
-                    "execution_providers": ["QNNExecutionProvider"]
+                    "execution_providers": [
+                        "QNNExecutionProvider"
+                    ]
                 }
             ]
         }
     },
     "passes": {
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": true,
+            "save_as_external_data": true
+        },
         "cb": {
             "type": "EPContextBinaryGenerator",
             "provider_options": {
@@ -26,7 +34,9 @@
             },
             "weight_sharing": true
         },
-        "cp": { "type": "ComposeOnnxModels" }
+        "cp": {
+            "type": "ComposeOnnxModels"
+        }
     },
     "target": "qnn_system",
     "log_severity_level": 1,


### PR DESCRIPTION
> **Draft / experimental — stacked on #527 (OpenVINO recipes).** Merge #527 first, then retarget this to `main`.

## Summary

Adds a two-step QNN/HTP flow for `google/gemma-4-E2B-it`, compiling each mobius component to a Snapdragon HTP context binary.

- **Step 1** — `qnn/build/config.json`: `MobiusBuilder(fp32, onnx-standard)` → portable decoder + vision + audio + embedding.
- **Step 2** — per-component compile:
  - `qnn/decoder/config.json`: full HTP LLM flow — `GraphSurgeries` → `OnnxStaticQuantization` → `SplitModel` → `StaticLLM` → `EPContextBinaryGenerator` → `ComposeOnnxModels` (wikitext calibration).
  - `qnn/{vision_encoder,audio_encoder,embedding}/config.json`: `EPContextBinaryGenerator(enable_htp_fp16_precision)` → `ComposeOnnxModels`.

## Validation status

⚠️ **HTP steps are NOT verified on hardware.** Building an HTP context binary requires the QNN SDK (`onnxruntime-qnn`) and a Snapdragon target; it cannot run on x86/CUDA. Verified on CPU:
- mobius `onnx-standard` build (decoder is 100% `ai.onnx`, no `com.microsoft` ops).
- decoder `GraphSurgeries` (`AttentionMaskToSequenceLengths` + `SimplifiedLayerNormToL2Norm`).

The ModelBuilder-specific `RemoveRopeMultiCache` surgery from the QNN reference flow was **removed** — it crashes (`IndexError`) on the mobius decoder, which uses a single `RotaryEmbedding` rather than ModelBuilder's multi-cache RoPE.

## Bring-up TODOs (documented in README)

- Set `python_environment_path` to a venv with `onnxruntime-qnn`, and `soc_model` for the target SoC.
- Tune `StaticLLM` `context_length` / `batch_size`.
- Optionally add per-modality static quantization (image/audio calibration) for the encoders.