### PR TITLE
Add Qwen3.5 and Qwen3.6 NvTensorRtRtx recipes

### DIFF
--- a/Qwen-Qwen3.5-0.8B/NvTensorRtRtx/Qwen3.5-0.8B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-0.8B/NvTensorRtRtx/Qwen3.5-0.8B_model_builder_int4.json
@@ -25,16 +25,11 @@
             "int4_block_size": 32,
             "int4_algo_config": "rtn",
             "int4_is_symmetric": true,
+            "use_qdq": true,
             "enable_cuda_graph": true,
             "extra_options": {
                 "exclude_embeds": false
             }
-        },
-        "mq": {
-            "type": "MatMulNBitsToQDQ",
-            "use_int4": true,
-            "add_zero_point": false,
-            "save_as_external_data": true
         }
     },
     "log_severity_level": 0

--- a/Qwen-Qwen3.5-0.8B/NvTensorRtRtx/Qwen3.5-0.8B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-0.8B/NvTensorRtRtx/Qwen3.5-0.8B_model_builder_int4.json
@@ -1,0 +1,41 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "Qwen/Qwen3.5-0.8B",
+        "task": "text-classification"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [
+                {
+                    "device": "gpu",
+                    "execution_providers": ["NvTensorRTRTXExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "engine": {
+        "target": "local_system"
+    },
+    "passes": {
+        "mb": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_block_size": 32,
+            "int4_algo_config": "rtn",
+            "int4_is_symmetric": true,
+            "enable_cuda_graph": true,
+            "extra_options": {
+                "exclude_embeds": false
+            }
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": false,
+            "save_as_external_data": true
+        }
+    },
+    "log_severity_level": 0
+}

--- a/Qwen-Qwen3.5-0.8B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-0.8B/NvTensorRtRtx/README.md
@@ -1,0 +1,27 @@
+# Qwen3.5-0.8B optimization
+
+This folder contains an Olive recipe for exporting the text-only component of `Qwen/Qwen3.5-0.8B` for the
+`NvTensorRTRTXExecutionProvider` (also known as the `NvTensorRtRtx` EP).
+
+## INT4 weight-only quantization
+
+The `Qwen3.5-0.8B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI `ModelBuilder` to:
+
+1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
+2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
+3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+
+The vision encoder is not exported.
+
+## Setup
+
+1. Install Olive.
+2. Install a Transformers 5.x release that recognizes the `qwen3_5` architecture.
+3. Install an ONNX Runtime GenAI package or build that supports Qwen3.5 hybrid models and the
+   `NvTensorRTRTXExecutionProvider`.
+
+## Run
+
+```bash
+olive run --config Qwen3.5-0.8B_model_builder_int4.json
+```

--- a/Qwen-Qwen3.5-0.8B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-0.8B/NvTensorRtRtx/README.md
@@ -9,7 +9,7 @@ The `Qwen3.5-0.8B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI `M
 
 1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
 2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
-3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+3. Export quantized matrix multiplications directly in INT4 QDQ format (`use_qdq=true`).
 
 The vision encoder is not exported.
 

--- a/Qwen-Qwen3.5-0.8B/NvTensorRtRtx/info.yml
+++ b/Qwen-Qwen3.5-0.8B/NvTensorRtRtx/info.yml
@@ -1,0 +1,6 @@
+arch: qwen3_5_text
+recipes:
+  - name: Qwen3.5-0.8B_Model_Builder_INT4
+    file: Qwen3.5-0.8B_model_builder_int4.json
+    devices: gpu
+    eps: NvTensorRTRTXExecutionProvider

--- a/Qwen-Qwen3.5-27B/NvTensorRtRtx/Qwen3.5-27B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-27B/NvTensorRtRtx/Qwen3.5-27B_model_builder_int4.json
@@ -25,16 +25,11 @@
             "int4_block_size": 32,
             "int4_algo_config": "rtn",
             "int4_is_symmetric": true,
+            "use_qdq": true,
             "enable_cuda_graph": true,
             "extra_options": {
                 "exclude_embeds": false
             }
-        },
-        "mq": {
-            "type": "MatMulNBitsToQDQ",
-            "use_int4": true,
-            "add_zero_point": false,
-            "save_as_external_data": true
         }
     },
     "log_severity_level": 0

--- a/Qwen-Qwen3.5-27B/NvTensorRtRtx/Qwen3.5-27B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-27B/NvTensorRtRtx/Qwen3.5-27B_model_builder_int4.json
@@ -1,0 +1,41 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "Qwen/Qwen3.5-27B",
+        "task": "text-classification"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [
+                {
+                    "device": "gpu",
+                    "execution_providers": ["NvTensorRTRTXExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "engine": {
+        "target": "local_system"
+    },
+    "passes": {
+        "mb": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_block_size": 32,
+            "int4_algo_config": "rtn",
+            "int4_is_symmetric": true,
+            "enable_cuda_graph": true,
+            "extra_options": {
+                "exclude_embeds": false
+            }
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": false,
+            "save_as_external_data": true
+        }
+    },
+    "log_severity_level": 0
+}

--- a/Qwen-Qwen3.5-27B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-27B/NvTensorRtRtx/README.md
@@ -1,0 +1,27 @@
+# Qwen3.5-27B optimization
+
+This folder contains an Olive recipe for exporting the text-only component of `Qwen/Qwen3.5-27B` for the
+`NvTensorRTRTXExecutionProvider` (also known as the `NvTensorRtRtx` EP).
+
+## INT4 weight-only quantization
+
+The `Qwen3.5-27B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI `ModelBuilder` to:
+
+1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
+2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
+3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+
+The vision encoder is not exported.
+
+## Setup
+
+1. Install Olive.
+2. Install a Transformers 5.x release that recognizes the `qwen3_5` architecture.
+3. Install an ONNX Runtime GenAI package or build that supports Qwen3.5 hybrid models and the
+   `NvTensorRTRTXExecutionProvider`.
+
+## Run
+
+```bash
+olive run --config Qwen3.5-27B_model_builder_int4.json
+```

--- a/Qwen-Qwen3.5-27B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-27B/NvTensorRtRtx/README.md
@@ -9,7 +9,7 @@ The `Qwen3.5-27B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI `Mo
 
 1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
 2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
-3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+3. Export quantized matrix multiplications directly in INT4 QDQ format (`use_qdq=true`).
 
 The vision encoder is not exported.
 

--- a/Qwen-Qwen3.5-27B/NvTensorRtRtx/info.yml
+++ b/Qwen-Qwen3.5-27B/NvTensorRtRtx/info.yml
@@ -1,0 +1,6 @@
+arch: qwen3_5_text
+recipes:
+  - name: Qwen3.5-27B_Model_Builder_INT4
+    file: Qwen3.5-27B_model_builder_int4.json
+    devices: gpu
+    eps: NvTensorRTRTXExecutionProvider

--- a/Qwen-Qwen3.5-2B/NvTensorRtRtx/Qwen3.5-2B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-2B/NvTensorRtRtx/Qwen3.5-2B_model_builder_int4.json
@@ -25,16 +25,11 @@
             "int4_block_size": 32,
             "int4_algo_config": "rtn",
             "int4_is_symmetric": true,
+            "use_qdq": true,
             "enable_cuda_graph": true,
             "extra_options": {
                 "exclude_embeds": false
             }
-        },
-        "mq": {
-            "type": "MatMulNBitsToQDQ",
-            "use_int4": true,
-            "add_zero_point": false,
-            "save_as_external_data": true
         }
     },
     "log_severity_level": 0

--- a/Qwen-Qwen3.5-2B/NvTensorRtRtx/Qwen3.5-2B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-2B/NvTensorRtRtx/Qwen3.5-2B_model_builder_int4.json
@@ -1,0 +1,41 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "Qwen/Qwen3.5-2B",
+        "task": "text-classification"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [
+                {
+                    "device": "gpu",
+                    "execution_providers": ["NvTensorRTRTXExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "engine": {
+        "target": "local_system"
+    },
+    "passes": {
+        "mb": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_block_size": 32,
+            "int4_algo_config": "rtn",
+            "int4_is_symmetric": true,
+            "enable_cuda_graph": true,
+            "extra_options": {
+                "exclude_embeds": false
+            }
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": false,
+            "save_as_external_data": true
+        }
+    },
+    "log_severity_level": 0
+}

--- a/Qwen-Qwen3.5-2B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-2B/NvTensorRtRtx/README.md
@@ -9,7 +9,7 @@ The `Qwen3.5-2B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI `Mod
 
 1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
 2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
-3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+3. Export quantized matrix multiplications directly in INT4 QDQ format (`use_qdq=true`).
 
 The vision encoder is not exported.
 

--- a/Qwen-Qwen3.5-2B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-2B/NvTensorRtRtx/README.md
@@ -1,0 +1,27 @@
+# Qwen3.5-2B optimization
+
+This folder contains an Olive recipe for exporting the text-only component of `Qwen/Qwen3.5-2B` for the
+`NvTensorRTRTXExecutionProvider` (also known as the `NvTensorRtRtx` EP).
+
+## INT4 weight-only quantization
+
+The `Qwen3.5-2B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI `ModelBuilder` to:
+
+1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
+2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
+3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+
+The vision encoder is not exported.
+
+## Setup
+
+1. Install Olive.
+2. Install a Transformers 5.x release that recognizes the `qwen3_5` architecture.
+3. Install an ONNX Runtime GenAI package or build that supports Qwen3.5 hybrid models and the
+   `NvTensorRTRTXExecutionProvider`.
+
+## Run
+
+```bash
+olive run --config Qwen3.5-2B_model_builder_int4.json
+```

--- a/Qwen-Qwen3.5-2B/NvTensorRtRtx/info.yml
+++ b/Qwen-Qwen3.5-2B/NvTensorRtRtx/info.yml
@@ -1,0 +1,6 @@
+arch: qwen3_5_text
+recipes:
+  - name: Qwen3.5-2B_Model_Builder_INT4
+    file: Qwen3.5-2B_model_builder_int4.json
+    devices: gpu
+    eps: NvTensorRTRTXExecutionProvider

--- a/Qwen-Qwen3.5-35B-A3B/NvTensorRtRtx/Qwen3.5-35B-A3B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-35B-A3B/NvTensorRtRtx/Qwen3.5-35B-A3B_model_builder_int4.json
@@ -25,16 +25,11 @@
             "int4_block_size": 32,
             "int4_algo_config": "rtn",
             "int4_is_symmetric": true,
+            "use_qdq": true,
             "enable_cuda_graph": true,
             "extra_options": {
                 "exclude_embeds": false
             }
-        },
-        "mq": {
-            "type": "MatMulNBitsToQDQ",
-            "use_int4": true,
-            "add_zero_point": false,
-            "save_as_external_data": true
         }
     },
     "log_severity_level": 0

--- a/Qwen-Qwen3.5-35B-A3B/NvTensorRtRtx/Qwen3.5-35B-A3B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-35B-A3B/NvTensorRtRtx/Qwen3.5-35B-A3B_model_builder_int4.json
@@ -1,0 +1,41 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "Qwen/Qwen3.5-35B-A3B",
+        "task": "text-classification"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [
+                {
+                    "device": "gpu",
+                    "execution_providers": ["NvTensorRTRTXExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "engine": {
+        "target": "local_system"
+    },
+    "passes": {
+        "mb": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_block_size": 32,
+            "int4_algo_config": "rtn",
+            "int4_is_symmetric": true,
+            "enable_cuda_graph": true,
+            "extra_options": {
+                "exclude_embeds": false
+            }
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": false,
+            "save_as_external_data": true
+        }
+    },
+    "log_severity_level": 0
+}

--- a/Qwen-Qwen3.5-35B-A3B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-35B-A3B/NvTensorRtRtx/README.md
@@ -9,7 +9,7 @@ The `Qwen3.5-35B-A3B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI
 
 1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
 2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
-3. Convert eligible `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+3. Export quantized matrix multiplications directly in INT4 QDQ format (`use_qdq=true`).
 
 The vision encoder is not exported.
 

--- a/Qwen-Qwen3.5-35B-A3B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-35B-A3B/NvTensorRtRtx/README.md
@@ -1,0 +1,27 @@
+# Qwen3.5-35B-A3B optimization
+
+This folder contains an Olive recipe for exporting the text-only component of `Qwen/Qwen3.5-35B-A3B` for the
+`NvTensorRTRTXExecutionProvider` (also known as the `NvTensorRtRtx` EP).
+
+## INT4 weight-only quantization
+
+The `Qwen3.5-35B-A3B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI `ModelBuilder` to:
+
+1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
+2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
+3. Convert eligible `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+
+The vision encoder is not exported.
+
+## Setup
+
+1. Install Olive.
+2. Install a Transformers 5.x release that recognizes the `qwen3_5_moe` architecture.
+3. Install an ONNX Runtime GenAI package or build that supports Qwen3.5 MoE hybrid models and the
+   `NvTensorRTRTXExecutionProvider`.
+
+## Run
+
+```bash
+olive run --config Qwen3.5-35B-A3B_model_builder_int4.json
+```

--- a/Qwen-Qwen3.5-35B-A3B/NvTensorRtRtx/info.yml
+++ b/Qwen-Qwen3.5-35B-A3B/NvTensorRtRtx/info.yml
@@ -1,0 +1,6 @@
+arch: qwen3_5_moe_text
+recipes:
+  - name: Qwen3.5-35B-A3B_Model_Builder_INT4
+    file: Qwen3.5-35B-A3B_model_builder_int4.json
+    devices: gpu
+    eps: NvTensorRTRTXExecutionProvider

--- a/Qwen-Qwen3.5-4B/NvTensorRtRtx/Qwen3.5-4B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-4B/NvTensorRtRtx/Qwen3.5-4B_model_builder_int4.json
@@ -25,16 +25,11 @@
             "int4_block_size": 32,
             "int4_algo_config": "rtn",
             "int4_is_symmetric": true,
+            "use_qdq": true,
             "enable_cuda_graph": true,
             "extra_options": {
                 "exclude_embeds": false
             }
-        },
-        "mq": {
-            "type": "MatMulNBitsToQDQ",
-            "use_int4": true,
-            "add_zero_point": false,
-            "save_as_external_data": true
         }
     },
     "log_severity_level": 0

--- a/Qwen-Qwen3.5-4B/NvTensorRtRtx/Qwen3.5-4B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-4B/NvTensorRtRtx/Qwen3.5-4B_model_builder_int4.json
@@ -1,0 +1,41 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "Qwen/Qwen3.5-4B",
+        "task": "text-classification"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [
+                {
+                    "device": "gpu",
+                    "execution_providers": ["NvTensorRTRTXExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "engine": {
+        "target": "local_system"
+    },
+    "passes": {
+        "mb": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_block_size": 32,
+            "int4_algo_config": "rtn",
+            "int4_is_symmetric": true,
+            "enable_cuda_graph": true,
+            "extra_options": {
+                "exclude_embeds": false
+            }
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": false,
+            "save_as_external_data": true
+        }
+    },
+    "log_severity_level": 0
+}

--- a/Qwen-Qwen3.5-4B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-4B/NvTensorRtRtx/README.md
@@ -1,0 +1,27 @@
+# Qwen3.5-4B optimization
+
+This folder contains an Olive recipe for exporting the text-only component of `Qwen/Qwen3.5-4B` for the
+`NvTensorRTRTXExecutionProvider` (also known as the `NvTensorRtRtx` EP).
+
+## INT4 weight-only quantization
+
+The `Qwen3.5-4B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI `ModelBuilder` to:
+
+1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
+2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
+3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+
+The vision encoder is not exported.
+
+## Setup
+
+1. Install Olive.
+2. Install a Transformers 5.x release that recognizes the `qwen3_5` architecture.
+3. Install an ONNX Runtime GenAI package or build that supports Qwen3.5 hybrid models and the
+   `NvTensorRTRTXExecutionProvider`.
+
+## Run
+
+```bash
+olive run --config Qwen3.5-4B_model_builder_int4.json
+```

--- a/Qwen-Qwen3.5-4B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-4B/NvTensorRtRtx/README.md
@@ -9,7 +9,7 @@ The `Qwen3.5-4B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI `Mod
 
 1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
 2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
-3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+3. Export quantized matrix multiplications directly in INT4 QDQ format (`use_qdq=true`).
 
 The vision encoder is not exported.
 

--- a/Qwen-Qwen3.5-4B/NvTensorRtRtx/info.yml
+++ b/Qwen-Qwen3.5-4B/NvTensorRtRtx/info.yml
@@ -1,0 +1,6 @@
+arch: qwen3_5_text
+recipes:
+  - name: Qwen3.5-4B_Model_Builder_INT4
+    file: Qwen3.5-4B_model_builder_int4.json
+    devices: gpu
+    eps: NvTensorRTRTXExecutionProvider

--- a/Qwen-Qwen3.5-9B/NvTensorRtRtx/Qwen3.5-9B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-9B/NvTensorRtRtx/Qwen3.5-9B_model_builder_int4.json
@@ -25,16 +25,11 @@
             "int4_block_size": 32,
             "int4_algo_config": "rtn",
             "int4_is_symmetric": true,
+            "use_qdq": true,
             "enable_cuda_graph": true,
             "extra_options": {
                 "exclude_embeds": false
             }
-        },
-        "mq": {
-            "type": "MatMulNBitsToQDQ",
-            "use_int4": true,
-            "add_zero_point": false,
-            "save_as_external_data": true
         }
     },
     "log_severity_level": 0

--- a/Qwen-Qwen3.5-9B/NvTensorRtRtx/Qwen3.5-9B_model_builder_int4.json
+++ b/Qwen-Qwen3.5-9B/NvTensorRtRtx/Qwen3.5-9B_model_builder_int4.json
@@ -1,0 +1,41 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "Qwen/Qwen3.5-9B",
+        "task": "text-classification"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [
+                {
+                    "device": "gpu",
+                    "execution_providers": ["NvTensorRTRTXExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "engine": {
+        "target": "local_system"
+    },
+    "passes": {
+        "mb": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_block_size": 32,
+            "int4_algo_config": "rtn",
+            "int4_is_symmetric": true,
+            "enable_cuda_graph": true,
+            "extra_options": {
+                "exclude_embeds": false
+            }
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": false,
+            "save_as_external_data": true
+        }
+    },
+    "log_severity_level": 0
+}

--- a/Qwen-Qwen3.5-9B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-9B/NvTensorRtRtx/README.md
@@ -1,0 +1,27 @@
+# Qwen3.5-9B optimization
+
+This folder contains an Olive recipe for exporting the text-only component of `Qwen/Qwen3.5-9B` for the
+`NvTensorRTRTXExecutionProvider` (also known as the `NvTensorRtRtx` EP).
+
+## INT4 weight-only quantization
+
+The `Qwen3.5-9B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI `ModelBuilder` to:
+
+1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
+2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
+3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+
+The vision encoder is not exported.
+
+## Setup
+
+1. Install Olive.
+2. Install a Transformers 5.x release that recognizes the `qwen3_5` architecture.
+3. Install an ONNX Runtime GenAI package or build that supports Qwen3.5 hybrid models and the
+   `NvTensorRTRTXExecutionProvider`.
+
+## Run
+
+```bash
+olive run --config Qwen3.5-9B_model_builder_int4.json
+```

--- a/Qwen-Qwen3.5-9B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.5-9B/NvTensorRtRtx/README.md
@@ -9,7 +9,7 @@ The `Qwen3.5-9B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI `Mod
 
 1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
 2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
-3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+3. Export quantized matrix multiplications directly in INT4 QDQ format (`use_qdq=true`).
 
 The vision encoder is not exported.
 

--- a/Qwen-Qwen3.5-9B/NvTensorRtRtx/info.yml
+++ b/Qwen-Qwen3.5-9B/NvTensorRtRtx/info.yml
@@ -1,0 +1,6 @@
+arch: qwen3_5_text
+recipes:
+  - name: Qwen3.5-9B_Model_Builder_INT4
+    file: Qwen3.5-9B_model_builder_int4.json
+    devices: gpu
+    eps: NvTensorRTRTXExecutionProvider

--- a/Qwen-Qwen3.6-27B/NvTensorRtRtx/Qwen3.6-27B_model_builder_int4.json
+++ b/Qwen-Qwen3.6-27B/NvTensorRtRtx/Qwen3.6-27B_model_builder_int4.json
@@ -25,16 +25,11 @@
             "int4_block_size": 32,
             "int4_algo_config": "rtn",
             "int4_is_symmetric": true,
+            "use_qdq": true,
             "enable_cuda_graph": true,
             "extra_options": {
                 "exclude_embeds": false
             }
-        },
-        "mq": {
-            "type": "MatMulNBitsToQDQ",
-            "use_int4": true,
-            "add_zero_point": false,
-            "save_as_external_data": true
         }
     },
     "log_severity_level": 0

--- a/Qwen-Qwen3.6-27B/NvTensorRtRtx/Qwen3.6-27B_model_builder_int4.json
+++ b/Qwen-Qwen3.6-27B/NvTensorRtRtx/Qwen3.6-27B_model_builder_int4.json
@@ -1,0 +1,41 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "Qwen/Qwen3.6-27B",
+        "task": "text-classification"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [
+                {
+                    "device": "gpu",
+                    "execution_providers": ["NvTensorRTRTXExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "engine": {
+        "target": "local_system"
+    },
+    "passes": {
+        "mb": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_block_size": 32,
+            "int4_algo_config": "rtn",
+            "int4_is_symmetric": true,
+            "enable_cuda_graph": true,
+            "extra_options": {
+                "exclude_embeds": false
+            }
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": false,
+            "save_as_external_data": true
+        }
+    },
+    "log_severity_level": 0
+}

--- a/Qwen-Qwen3.6-27B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.6-27B/NvTensorRtRtx/README.md
@@ -1,0 +1,28 @@
+# Qwen3.6-27B optimization
+
+This folder contains an Olive recipe for exporting the text-only component of `Qwen/Qwen3.6-27B` for the
+`NvTensorRTRTXExecutionProvider` (also known as the `NvTensorRtRtx` EP).
+
+## INT4 weight-only quantization
+
+The `Qwen3.6-27B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI Qwen3.5 hybrid model builder, which
+matches the architecture declared by the Qwen3.6 checkpoint, to:
+
+1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
+2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
+3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+
+The vision encoder is not exported.
+
+## Setup
+
+1. Install Olive.
+2. Install a Transformers 5.x release that recognizes the `qwen3_5` architecture.
+3. Install an ONNX Runtime GenAI package or build that supports Qwen3.5 hybrid models and the
+   `NvTensorRTRTXExecutionProvider`.
+
+## Run
+
+```bash
+olive run --config Qwen3.6-27B_model_builder_int4.json
+```

--- a/Qwen-Qwen3.6-27B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.6-27B/NvTensorRtRtx/README.md
@@ -10,7 +10,7 @@ matches the architecture declared by the Qwen3.6 checkpoint, to:
 
 1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
 2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
-3. Convert `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+3. Export quantized matrix multiplications directly in INT4 QDQ format (`use_qdq=true`).
 
 The vision encoder is not exported.
 

--- a/Qwen-Qwen3.6-27B/NvTensorRtRtx/info.yml
+++ b/Qwen-Qwen3.6-27B/NvTensorRtRtx/info.yml
@@ -1,0 +1,6 @@
+arch: qwen3_5_text
+recipes:
+  - name: Qwen3.6-27B_Model_Builder_INT4
+    file: Qwen3.6-27B_model_builder_int4.json
+    devices: gpu
+    eps: NvTensorRTRTXExecutionProvider

--- a/Qwen-Qwen3.6-35B-A3B/NvTensorRtRtx/Qwen3.6-35B-A3B_model_builder_int4.json
+++ b/Qwen-Qwen3.6-35B-A3B/NvTensorRtRtx/Qwen3.6-35B-A3B_model_builder_int4.json
@@ -25,16 +25,11 @@
             "int4_block_size": 32,
             "int4_algo_config": "rtn",
             "int4_is_symmetric": true,
+            "use_qdq": true,
             "enable_cuda_graph": true,
             "extra_options": {
                 "exclude_embeds": false
             }
-        },
-        "mq": {
-            "type": "MatMulNBitsToQDQ",
-            "use_int4": true,
-            "add_zero_point": false,
-            "save_as_external_data": true
         }
     },
     "log_severity_level": 0

--- a/Qwen-Qwen3.6-35B-A3B/NvTensorRtRtx/Qwen3.6-35B-A3B_model_builder_int4.json
+++ b/Qwen-Qwen3.6-35B-A3B/NvTensorRtRtx/Qwen3.6-35B-A3B_model_builder_int4.json
@@ -1,0 +1,41 @@
+{
+    "input_model": {
+        "type": "HfModel",
+        "model_path": "Qwen/Qwen3.6-35B-A3B",
+        "task": "text-classification"
+    },
+    "systems": {
+        "local_system": {
+            "type": "LocalSystem",
+            "accelerators": [
+                {
+                    "device": "gpu",
+                    "execution_providers": ["NvTensorRTRTXExecutionProvider"]
+                }
+            ]
+        }
+    },
+    "engine": {
+        "target": "local_system"
+    },
+    "passes": {
+        "mb": {
+            "type": "ModelBuilder",
+            "precision": "int4",
+            "int4_block_size": 32,
+            "int4_algo_config": "rtn",
+            "int4_is_symmetric": true,
+            "enable_cuda_graph": true,
+            "extra_options": {
+                "exclude_embeds": false
+            }
+        },
+        "mq": {
+            "type": "MatMulNBitsToQDQ",
+            "use_int4": true,
+            "add_zero_point": false,
+            "save_as_external_data": true
+        }
+    },
+    "log_severity_level": 0
+}

--- a/Qwen-Qwen3.6-35B-A3B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.6-35B-A3B/NvTensorRtRtx/README.md
@@ -1,0 +1,28 @@
+# Qwen3.6-35B-A3B optimization
+
+This folder contains an Olive recipe for exporting the text-only component of `Qwen/Qwen3.6-35B-A3B` for the
+`NvTensorRTRTXExecutionProvider` (also known as the `NvTensorRtRtx` EP).
+
+## INT4 weight-only quantization
+
+The `Qwen3.6-35B-A3B_model_builder_int4.json` recipe uses the ONNX Runtime GenAI Qwen3.5 MoE hybrid model builder,
+which matches the architecture declared by the Qwen3.6 checkpoint, to:
+
+1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
+2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
+3. Convert eligible `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+
+The vision encoder is not exported.
+
+## Setup
+
+1. Install Olive.
+2. Install a Transformers 5.x release that recognizes the `qwen3_5_moe` architecture.
+3. Install an ONNX Runtime GenAI package or build that supports Qwen3.5 MoE hybrid models and the
+   `NvTensorRTRTXExecutionProvider`.
+
+## Run
+
+```bash
+olive run --config Qwen3.6-35B-A3B_model_builder_int4.json
+```

--- a/Qwen-Qwen3.6-35B-A3B/NvTensorRtRtx/README.md
+++ b/Qwen-Qwen3.6-35B-A3B/NvTensorRtRtx/README.md
@@ -10,7 +10,7 @@ which matches the architecture declared by the Qwen3.6 checkpoint, to:
 
 1. Export a standalone text model by including the token embedding layer (`exclude_embeds=false`).
 2. Apply symmetric INT4 RTN weight-only quantization with a block size of 32.
-3. Convert eligible `MatMulNBits` nodes to an INT4 QDQ representation with the `MatMulNBitsToQDQ` pass.
+3. Export quantized matrix multiplications directly in INT4 QDQ format (`use_qdq=true`).
 
 The vision encoder is not exported.
 

--- a/Qwen-Qwen3.6-35B-A3B/NvTensorRtRtx/info.yml
+++ b/Qwen-Qwen3.6-35B-A3B/NvTensorRtRtx/info.yml
@@ -1,0 +1,6 @@
+arch: qwen3_5_moe_text
+recipes:
+  - name: Qwen3.6-35B-A3B_Model_Builder_INT4
+    file: Qwen3.6-35B-A3B_model_builder_int4.json
+    devices: gpu
+    eps: NvTensorRTRTXExecutionProvider


### PR DESCRIPTION
## Summary

Add NvTensorRtRtx text-only recipes for Qwen3.5-0.8B, 2B, 4B, 9B, 27B, and 35B-A3B, and Qwen3.6-27B and 35B-A3B. The recipes use symmetric INT4 RTN weight-only quantization with block size 32, followed by `MatMulNBitsToQDQ` conversion for NvTensorRtRtx.

## Validation

- Parsed all eight workflows with Olive and validated their JSON and metadata.
- Exported Qwen3.5-0.8B through both passes; the final graph contained 187 `DequantizeLinear` nodes and no `MatMulNBits` nodes.
- Exported Qwen3.6-35B-A3B through both passes; the final 17.555 GiB graph contained 391 `DequantizeLinear` nodes, no `MatMulNBits` nodes, and valid external-data references.
- Confirmed the Qwen3.6-35B-A3B GenAI configuration uses `qwen3_5_moe_text` with the NvTensorRtRtx provider.
