### PR TITLE
[feat] Qwen3-VL-4B: export DeepStack visual features for per-layer injection

### DIFF
--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/codes/modeling_qwen3_vl.py
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/codes/modeling_qwen3_vl.py
@@ -466,7 +466,11 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
                 The temporal, height and width of feature shape of each image in LLM.
 
         Returns:
-            `torch.Tensor`: hidden_states (merged image features).
+            tuple of `torch.Tensor`:
+                - image_features (merged image features), shape `(num_logical_patches, out_hidden_size)`
+                - deepstack_feature_0/1/2: the per-index DeepStack features (same shape), captured at
+                  `deepstack_visual_indexes` and passed through their patch mergers. Returned separately
+                  (NOT folded into image_features) so the text decoder can inject them per-layer.
         """
         hidden_states = self.patch_embed(hidden_states)
 
@@ -487,8 +491,13 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
         )
         cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
 
-        # NOTE: DeepStack features are not exported separately for ONNX.
-        # They are handled by the text model builder (ModelBuilder) in the text.json pass.
+        # DeepStack: capture visual features at the configured layers and run them
+        # through their per-index patch mergers. Return them SEPARATELY (not folded
+        # into the merged features) so the text decoder can inject each into its
+        # corresponding early layer (feature[i] -> decoder layer i), matching HF's
+        # layer-wise deepstack injection exactly instead of the input-embedding
+        # approximation.
+        deepstack_feats = []
         for layer_num, blk in enumerate(self.blocks):
             hidden_states = blk(
                 hidden_states,
@@ -496,10 +505,14 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
                 position_embeddings=position_embeddings,
                 **kwargs,
             )
+            if layer_num in self.deepstack_visual_indexes:
+                ds_idx = self.deepstack_visual_indexes.index(layer_num)
+                deepstack_feats.append(self.deepstack_merger_list[ds_idx](hidden_states))
 
         hidden_states = self.merger(hidden_states)
 
-        return hidden_states
+        # image_features + one output per deepstack index (3 for case2: indexes [5, 11, 17])
+        return (hidden_states, *deepstack_feats)
 
 
 @dataclass
@@ -862,24 +875,38 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
     def get_image_features(self, pixel_values: torch.FloatTensor, image_grid_thw: Optional[torch.LongTensor] = None):
         """
         Encodes images into continuous embeddings that can be forwarded to the language model.
-        For ONNX export, only returns the main merged features (no deepstack).
+
+        Returns a tuple `(image_features, deepstack_0, deepstack_1, deepstack_2)`. vision.onnx is
+        exported single-image (VisionState loops per-image in C++), so no per-image split is needed;
+        the DeepStack features are returned separately for per-layer injection in the text decoder.
         """
         pixel_values = pixel_values.type(self.visual.dtype)
-        image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
-        split_sizes = (image_grid_thw.prod(-1) // self.visual.spatial_merge_size**2).tolist()
-        image_embeds = torch.split(image_embeds, split_sizes)
-        return image_embeds
+        image_features, *deepstack_feats = self.visual(pixel_values, grid_thw=image_grid_thw)
+        return (image_features, *deepstack_feats)
 
-    def get_fused_input_embeddings(self, input_ids, image_features=None):
+    def get_fused_input_embeddings(
+        self,
+        input_ids,
+        image_features=None,
+        deepstack_features_0=None,
+        deepstack_features_1=None,
+        deepstack_features_2=None,
+    ):
         """
-        Fuses the input embeddings from the language model with the image features.
+        Fuses the input embeddings from the language model with the image features, and scatters
+        the three per-token DeepStack features into full-length (batch, seq, hidden) tensors so the
+        text decoder can inject them with plain static Adds at layers 0/1/2.
 
         Args:
             input_ids (`torch.LongTensor`): The input IDs for the language model.
             image_features (`torch.FloatTensor`, optional): The image features to fuse with the input embeddings.
+            deepstack_features_0/1/2 (`torch.FloatTensor`, optional): per-token DeepStack features
+                (same shape as image_features) for decoder layers 0/1/2.
 
         Returns:
-            `torch.FloatTensor`: The fused input embeddings.
+            tuple `(inputs_embeds, deepstack_0_full, deepstack_1_full, deepstack_2_full)`, where each
+            `deepstack_i_full` is a zero tensor with `deepstack_features_i` scattered into image-token
+            positions (or all-zeros during generation when there are no image tokens).
         """
         def true_fn_for_input_ids(input_ids):
             special_image_mask = input_ids == self.config.image_token_id
@@ -898,24 +925,32 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
 
         inputs_embeds = self.language_model.get_input_embeddings()(llm_input_ids)
 
-        def image_features_is_none(inputs_embeds, image_features=None):
-            return inputs_embeds
+        def image_features_is_none(inputs_embeds, image_features, ds0, ds1, ds2):
+            zeros = torch.zeros_like(inputs_embeds)
+            return inputs_embeds, zeros, zeros.clone(), zeros.clone()
 
-        def image_features_is_not_none(inputs_embeds, image_features=None):
+        def image_features_is_not_none(inputs_embeds, image_features, ds0, ds1, ds2):
             special_image_mask = (llm_input_ids == self.config.image_token_id).unsqueeze(-1)
             special_image_mask = special_image_mask.expand_as(inputs_embeds).to(inputs_embeds.device)
             image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
             inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
-            return inputs_embeds
 
-        inputs_embeds = torch.cond(
+            ds0 = ds0.to(inputs_embeds.device, inputs_embeds.dtype)
+            ds1 = ds1.to(inputs_embeds.device, inputs_embeds.dtype)
+            ds2 = ds2.to(inputs_embeds.device, inputs_embeds.dtype)
+            ds0_full = torch.zeros_like(inputs_embeds).masked_scatter(special_image_mask, ds0)
+            ds1_full = torch.zeros_like(inputs_embeds).masked_scatter(special_image_mask, ds1)
+            ds2_full = torch.zeros_like(inputs_embeds).masked_scatter(special_image_mask, ds2)
+            return inputs_embeds, ds0_full, ds1_full, ds2_full
+
+        inputs_embeds, ds0_full, ds1_full, ds2_full = torch.cond(
             image_features is None,
             image_features_is_none,
             image_features_is_not_none,
-            (inputs_embeds, image_features,)
+            (inputs_embeds, image_features, deepstack_features_0, deepstack_features_1, deepstack_features_2,)
         )
 
-        return inputs_embeds
+        return inputs_embeds, ds0_full, ds1_full, ds2_full
 
     def get_rope_index(
         self,

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/codes/modeling_qwen3_vl.py
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/codes/modeling_qwen3_vl.py
@@ -930,17 +930,25 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
             return inputs_embeds, zeros, zeros.clone(), zeros.clone()
 
         def image_features_is_not_none(inputs_embeds, image_features, ds0, ds1, ds2):
-            special_image_mask = (llm_input_ids == self.config.image_token_id).unsqueeze(-1)
-            special_image_mask = special_image_mask.expand_as(inputs_embeds).to(inputs_embeds.device)
+            # Row-wise index_put, not masked_scatter: the latter needs a mask expanded to
+            # [B, S, H], which exports to a per-element ScatterND whose int64 index costs
+            # ~126MB at S=8k/H=2560 (and once per scattered output). Indexing on
+            # (batch, position) scatters whole rows off a [num_image_tokens, 2] index.
+            batch_idx, pos_idx = torch.nonzero(
+                llm_input_ids == self.config.image_token_id, as_tuple=True
+            )
+            # masked_scatter ignores trailing source rows; index_put requires an exact match.
+            num_rows = batch_idx.shape[0]
+
             image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
-            inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
+            inputs_embeds = inputs_embeds.index_put((batch_idx, pos_idx), image_features[:num_rows])
 
             ds0 = ds0.to(inputs_embeds.device, inputs_embeds.dtype)
             ds1 = ds1.to(inputs_embeds.device, inputs_embeds.dtype)
             ds2 = ds2.to(inputs_embeds.device, inputs_embeds.dtype)
-            ds0_full = torch.zeros_like(inputs_embeds).masked_scatter(special_image_mask, ds0)
-            ds1_full = torch.zeros_like(inputs_embeds).masked_scatter(special_image_mask, ds1)
-            ds2_full = torch.zeros_like(inputs_embeds).masked_scatter(special_image_mask, ds2)
+            ds0_full = torch.zeros_like(inputs_embeds).index_put((batch_idx, pos_idx), ds0[:num_rows])
+            ds1_full = torch.zeros_like(inputs_embeds).index_put((batch_idx, pos_idx), ds1[:num_rows])
+            ds2_full = torch.zeros_like(inputs_embeds).index_put((batch_idx, pos_idx), ds2[:num_rows])
             return inputs_embeds, ds0_full, ds1_full, ds2_full
 
         inputs_embeds, ds0_full, ds1_full, ds2_full = torch.cond(

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/codes/modeling_qwen3_vl.py
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/codes/modeling_qwen3_vl.py
@@ -924,6 +924,10 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
         )
 
         inputs_embeds = self.language_model.get_input_embeddings()(llm_input_ids)
+        # bf16 from here on: the decoder's first op on each of the four full-length outputs is a
+        # cast to bf16 anyway, so doing it before the scatter halves both the embedding->decoder
+        # buffers genai shares and the decoder's cast temporaries. Same rounding, same values.
+        inputs_embeds = inputs_embeds.to(torch.bfloat16)
 
         def image_features_is_none(inputs_embeds, image_features, ds0, ds1, ds2):
             zeros = torch.zeros_like(inputs_embeds)
@@ -940,12 +944,19 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
             # masked_scatter ignores trailing source rows; index_put requires an exact match.
             num_rows = batch_idx.shape[0]
 
-            image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            # match() rather than .to(device, dtype): device and dtype are both static during
+            # export, so the guards fold away and no Cast is emitted when the features already
+            # arrive as bf16. An unconditional .to() -- either argument -- traces to a Cast
+            # regardless, leaving four full-width no-op copies behind.
+            def match(t):
+                if t.device != inputs_embeds.device:
+                    t = t.to(inputs_embeds.device)
+                return t if t.dtype == inputs_embeds.dtype else t.to(inputs_embeds.dtype)
+
+            image_features = match(image_features)
             inputs_embeds = inputs_embeds.index_put((batch_idx, pos_idx), image_features[:num_rows])
 
-            ds0 = ds0.to(inputs_embeds.device, inputs_embeds.dtype)
-            ds1 = ds1.to(inputs_embeds.device, inputs_embeds.dtype)
-            ds2 = ds2.to(inputs_embeds.device, inputs_embeds.dtype)
+            ds0, ds1, ds2 = match(ds0), match(ds1), match(ds2)
             ds0_full = torch.zeros_like(inputs_embeds).index_put((batch_idx, pos_idx), ds0[:num_rows])
             ds1_full = torch.zeros_like(inputs_embeds).index_put((batch_idx, pos_idx), ds1[:num_rows])
             ds2_full = torch.zeros_like(inputs_embeds).index_put((batch_idx, pos_idx), ds2[:num_rows])

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/cpu_and_mobile/vision.json
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/cpu_and_mobile/vision.json
@@ -23,6 +23,24 @@
                     "output_idx": 0,
                     "dim_idx": 0,
                     "dim_name": "num_logical_patches"
+                },
+                {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 1,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
+                },
+                {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 2,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
+                },
+                {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 3,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
                 }
             ]
         },

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/cpu_and_mobile/vision.json
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/cpu_and_mobile/vision.json
@@ -57,22 +57,6 @@
             "fuse_reshape_operations": false,
             "fix_com_microsoft_opset": true,
             "cast_chain_elimination": true
-        },
-        "gs2": {
-            "type": "GraphSurgeries",
-            "surgeries": [
-                {
-                    "surgeon": "GemmToMatMulAdd"
-                }
-            ]
-        },
-        "int4": {
-            "type": "OnnxBlockWiseRtnQuantization",
-            "block_size": 128,
-            "is_symmetric": true,
-            "accuracy_level": 4,
-            "save_as_external_data": true,
-            "external_data_name": "vision.onnx.data"
         }
     },
     "no_artifacts": true,

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/cuda/vision.json
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/cuda/vision.json
@@ -26,6 +26,24 @@
                     "output_idx": 0,
                     "dim_idx": 0,
                     "dim_name": "num_logical_patches"
+                },
+                {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 1,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
+                },
+                {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 2,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
+                },
+                {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 3,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
                 }
             ]
         },

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/optimize.py
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/optimize.py
@@ -68,11 +68,21 @@ def update_genai_config(output_dir: str = MODELS_DIR, device: str = "gpu"):
 
     session_options = {"log_id": "onnxruntime-genai", "provider_options": provider_options}
 
+    # Qwen3-VL DeepStack: vision emits one extra per-token feature per deepstack_visual_index
+    # (3 for the 4B model: vision layers [5, 11, 17]). embedding.onnx scatters them to full
+    # length; the decoder injects them after layers 0/1/2.
+    deepstack_features = [f"deepstack_features_{i}" for i in range(3)]
+    deepstack_full = [f"deepstack_{i}" for i in range(3)]
+
     # Embedding configuration
     config["model"]["embedding"] = {
         "filename": "embedding.onnx",
-        "inputs": {"input_ids": "input_ids", "image_features": "image_features"},
-        "outputs": {"inputs_embeds": "inputs_embeds"},
+        "inputs": {
+            "input_ids": "input_ids",
+            "image_features": "image_features",
+            "deepstack_features": deepstack_features,
+        },
+        "outputs": {"inputs_embeds": "inputs_embeds", "deepstack": deepstack_full},
         "session_options": session_options,
     }
 
@@ -84,9 +94,12 @@ def update_genai_config(output_dir: str = MODELS_DIR, device: str = "gpu"):
         "tokens_per_second": 2.0,
         "patch_size": 16,
         "inputs": {"pixel_values": "pixel_values", "image_grid_thw": "image_grid_thw"},
-        "outputs": {"image_features": "image_features"},
+        "outputs": {"image_features": "image_features", "deepstack_features": deepstack_features},
         "session_options": session_options,
     }
+
+    # Decoder consumes the full-length scattered DeepStack features (from embedding).
+    config["model"].setdefault("decoder", {}).setdefault("inputs", {})["deepstack"] = deepstack_full
 
     config["model"]["image_token_id"] = 151655
     config["model"]["video_token_id"] = 151656

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/user_script.py
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/user_script.py
@@ -119,16 +119,18 @@ def get_embedding_dummy_inputs(model=None):
         "image_features": torch.randn(
             num_logical_patches,
             out_hidden_size,
-            dtype=torch.float32,  # fp32 to match embedding model export dtype
+            # bf16 in, bf16 out: the vision model already rounds these to bf16 on the NPU and
+            # the scatter runs in bf16, so exporting them as fp32 only buys a cast back down
+            dtype=torch.bfloat16,
         ),
         "deepstack_features_0": torch.randn(
-            num_logical_patches, out_hidden_size, dtype=torch.float32
+            num_logical_patches, out_hidden_size, dtype=torch.bfloat16
         ),
         "deepstack_features_1": torch.randn(
-            num_logical_patches, out_hidden_size, dtype=torch.float32
+            num_logical_patches, out_hidden_size, dtype=torch.bfloat16
         ),
         "deepstack_features_2": torch.randn(
-            num_logical_patches, out_hidden_size, dtype=torch.float32
+            num_logical_patches, out_hidden_size, dtype=torch.bfloat16
         ),
     }
 

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/user_script.py
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/user_script.py
@@ -20,12 +20,15 @@ def _load_base_model(model_path):
     """Load weights directly from safetensors, stripping 'model.' prefix,
     into our custom Qwen3VLModel without loading the full HF model."""
     from safetensors.torch import load_file
-    from huggingface_hub import hf_hub_download
     import glob
 
-    # Find safetensors file(s) in cache
-    config_path = hf_hub_download(model_path, 'config.json')
-    model_dir = os.path.dirname(config_path)
+    # Find safetensors file(s): support local directory or HF hub repo id
+    if model_path and os.path.isdir(model_path):
+        model_dir = model_path
+    else:
+        from huggingface_hub import hf_hub_download
+        config_path = hf_hub_download(model_path, 'config.json')
+        model_dir = os.path.dirname(config_path)
     st_files = sorted(glob.glob(os.path.join(model_dir, '*.safetensors')))
 
     # Load and strip 'model.' prefix, keeping native bfloat16 precision
@@ -66,11 +69,23 @@ def get_embedding_io_config(model_path=None):
     dynamic_axes = {
         "input_ids": {0: "batch_size", 1: "sequence_length"},
         "image_features": {0: "num_logical_patches"},
+        "deepstack_features_0": {0: "num_logical_patches"},
+        "deepstack_features_1": {0: "num_logical_patches"},
+        "deepstack_features_2": {0: "num_logical_patches"},
         "inputs_embeds": {0: "batch_size", 1: "sequence_length"},
+        "deepstack_0": {0: "batch_size", 1: "sequence_length"},
+        "deepstack_1": {0: "batch_size", 1: "sequence_length"},
+        "deepstack_2": {0: "batch_size", 1: "sequence_length"},
     }
     return {
-        "input_names": ["input_ids", "image_features"],
-        "output_names": ["inputs_embeds"],
+        "input_names": [
+            "input_ids",
+            "image_features",
+            "deepstack_features_0",
+            "deepstack_features_1",
+            "deepstack_features_2",
+        ],
+        "output_names": ["inputs_embeds", "deepstack_0", "deepstack_1", "deepstack_2"],
         "dynamic_axes": dynamic_axes,
     }
 
@@ -106,6 +121,15 @@ def get_embedding_dummy_inputs(model=None):
             out_hidden_size,
             dtype=torch.float32,  # fp32 to match embedding model export dtype
         ),
+        "deepstack_features_0": torch.randn(
+            num_logical_patches, out_hidden_size, dtype=torch.float32
+        ),
+        "deepstack_features_1": torch.randn(
+            num_logical_patches, out_hidden_size, dtype=torch.float32
+        ),
+        "deepstack_features_2": torch.randn(
+            num_logical_patches, out_hidden_size, dtype=torch.float32
+        ),
     }
 
     img_start_index = 3
@@ -127,6 +151,9 @@ def get_embedding_dummy_inputs(model=None):
     return {
         "input_ids": inputs["input_ids"],  # input_ids: torch.LongTensor
         "image_features": inputs["image_features"],  # image_features: Optional[torch.FloatTensor] = None,
+        "deepstack_features_0": inputs["deepstack_features_0"],
+        "deepstack_features_1": inputs["deepstack_features_1"],
+        "deepstack_features_2": inputs["deepstack_features_2"],
     }
 
 
@@ -144,7 +171,12 @@ def get_vision_io_config(model_path=None):
     # image_grid_thw is static: shape [num_images, 3] is fixed at trace time.
     return {
         "input_names": ["pixel_values", "image_grid_thw"],
-        "output_names": ["image_features"],
+        "output_names": [
+            "image_features",
+            "deepstack_features_0",
+            "deepstack_features_1",
+            "deepstack_features_2",
+        ],
         "dynamic_shapes": {
             "pixel_values": {0: "num_patches"},
             "image_grid_thw": None,


### PR DESCRIPTION
# Summary
Updates the Qwen3-VL-4B export recipe so the vision and embedding ONNX models emit the three DeepStack feature tensors required for correct multimodal inference. Pairs with the onnxruntime-genai runtime change that injects these after decoder layers 0/1/2. Fixes image-input collapse (few repeated boxes / degenerate loops) caused by dropping 3 of the model's 4 visual injection points.

# Background
Qwen3-VL injects visual features at four points: the input embedding plus decoder layers 0/1/2 (deepstack_visual_indexes = [5, 11, 17]). The previous recipe only exported the merged input-embedding features and discarded DeepStack, which a PyTorch ablation confirms is sufficient to reproduce the collapse. This PR exports all four.

# Changes

  - codes/modeling_qwen3_vl.py
    - Qwen3VLVisionModel.forward / get_image_features: return 4 outputs — image_features plus deepstack_features_0/1/2 (each routed through its own
  deepstack_merger_list[i], per-token [num_logical_patches, 2560]).
    - get_fused_input_embeddings (embedding forward): accept 3 per-token DeepStack inputs, reuse the existing input_ids == image_token_id mask to masked_scatter
   each into a zero [batch, seq, 2560], and return inputs_embeds + deepstack_0/1/2 (full-length, pre-scattered).
  - user_script.py
    - get_vision_io_config: add 3 output names + dynamic_shapes (dim0 = num_logical_patches).
    - get_embedding_io_config: add 3 input names + 3 output names + dynamic_axes.
    - get_embedding_dummy_inputs: add 3 [num_logical_patches, 2560] dummy tensors.
  - cpu_and_mobile/vision.json and cuda/vision.json: add RenameOutputDims for each new DeepStack output so dim0 = num_logical_patches is preserved fordownstream shape inference / concatenation.
  - optimize.py (update_genai_config): declare the new tensors in the generated genai_config.json — vision.outputs += deepstack_features_0/1/2, embedding.inputs/outputs += deepstack_*, decoder.inputs += deepstack_0/1/2.

# Notes
  - Vision is still exported single-image (variable image count handled by the genai runtime), keeping the graph NPU-partitionable.
  - Naming: per-token = deepstack_features_N (vision outputs / embedding inputs); full-length scattered = deepstack_N (embedding outputs / decoder inputs).

# Testing
Re-exported vision + embedding, rebuilt the decoder via the paired genai ModelBuilder, ran CPU genai vs Qwen3-VL PyTorch golden:
  - Full 79-image layout benchmark: F1 0.997 / meanIoU 0.984 / typeAcc 0.996, 0 collapse. Prior export (no DeepStack): F1 0.039.
  - Dense-page spot checks match golden box-for-box within ±1–3px.