### PR TITLE
Enable long CL for Phi 3 recipes

### DIFF
--- a/microsoft-Phi-3-mini-128k-instruct/QNN/config.json
+++ b/microsoft-Phi-3-mini-128k-instruct/QNN/config.json
@@ -60,7 +60,7 @@
         "gs": {
             "type": "GraphSurgeries",
             "surgeries": [
-                { "surgeon": "RemoveRopeMultiCache" },
+                { "surgeon": "RemoveRopeMultiCache", "use_large_cache": true},
                 { "surgeon": "AttentionMaskToSequenceLengths" },
                 { "surgeon": "SimplifiedLayerNormToL2Norm" }
             ],

--- a/microsoft-Phi-3-mini-128k-instruct/QNN/config.json
+++ b/microsoft-Phi-3-mini-128k-instruct/QNN/config.json
@@ -60,7 +60,7 @@
         "gs": {
             "type": "GraphSurgeries",
             "surgeries": [
-                { "surgeon": "RemoveRopeMultiCache", "use_large_cache": true},
+                { "surgeon": "RemoveRopeMultiCache", "use_large_cache": true },
                 { "surgeon": "AttentionMaskToSequenceLengths" },
                 { "surgeon": "SimplifiedLayerNormToL2Norm" }
             ],

--- a/microsoft-Phi-3.5-mini-instruct/QNN/x2_elite_config.json
+++ b/microsoft-Phi-3.5-mini-instruct/QNN/x2_elite_config.json
@@ -64,7 +64,7 @@
         "gs": {
             "type": "GraphSurgeries",
             "surgeries": [
-                { "surgeon": "RemoveRopeMultiCache" },
+                { "surgeon": "RemoveRopeMultiCache", "use_large_cache": true },
                 { "surgeon": "AttentionMaskToSequenceLengths" },
                 { "surgeon": "RemoveGidxFromMatMulNBits" },
                 { "surgeon": "SimplifiedLayerNormToL2Norm" }

--- a/microsoft-Phi-3.5-mini-instruct/QNN/x_elite_config.json
+++ b/microsoft-Phi-3.5-mini-instruct/QNN/x_elite_config.json
@@ -64,7 +64,7 @@
         "gs": {
             "type": "GraphSurgeries",
             "surgeries": [
-                { "surgeon": "RemoveRopeMultiCache" },
+                { "surgeon": "RemoveRopeMultiCache", "use_large_cache": true},
                 { "surgeon": "AttentionMaskToSequenceLengths" },
                 { "surgeon": "RemoveGidxFromMatMulNBits" },
                 { "surgeon": "SimplifiedLayerNormToL2Norm" }


### PR DESCRIPTION
Enables long CL support for the following recipes:

- Microsoft Phi-3.5-mini-instruct
- Microsoft Phi-3-mini-128k-instruct

Updates the corresponding QNN configuration files for both models.