### PR TITLE
Fix Mobius package dependencies

### DIFF
--- a/Qwen-Qwen3.5-0.8B/ortpackage/requirements.txt
+++ b/Qwen-Qwen3.5-0.8B/ortpackage/requirements.txt
@@ -1,2 +1,3 @@
-olive-ai[mobius-ai]>=0.13.0
+mobius-onnx
+olive-ai>=0.13.0
 onnxruntime-genai>=0.15.0

--- a/google-gemma-4-E2B-it/README.md
+++ b/google-gemma-4-E2B-it/README.md
@@ -16,7 +16,6 @@ post-processing required.
 ## Prerequisites
 
 ```bash
-pip install olive-ai mobius-onnx
 pip install -r requirements.txt
 ```
 

--- a/google-gemma-4-E2B-it/README.md
+++ b/google-gemma-4-E2B-it/README.md
@@ -16,7 +16,7 @@ post-processing required.
 ## Prerequisites
 
 ```bash
-pip install olive-ai mobius-ai
+pip install olive-ai mobius-onnx
 pip install -r requirements.txt
 ```
 

--- a/google-gemma-4-E2B-it/requirements.txt
+++ b/google-gemma-4-E2B-it/requirements.txt
@@ -1,3 +1,3 @@
 lm-eval
-mobius-ai
+mobius-onnx
 olive-ai[gpu]

--- a/google-gemma-4-E2B-it/requirements.txt
+++ b/google-gemma-4-E2B-it/requirements.txt
@@ -1,3 +1,3 @@
 lm-eval
 mobius-onnx
-olive-ai[gpu]
+olive-ai[gpu]>=0.13.0

--- a/microsoft-Phi-4-mini-reasoning/ortpackage/requirements.txt
+++ b/microsoft-Phi-4-mini-reasoning/ortpackage/requirements.txt
@@ -1,2 +1,3 @@
-olive-ai[mobius-ai]>=0.13.0
+mobius-onnx
+olive-ai>=0.13.0
 onnxruntime-genai>=0.15.0


### PR DESCRIPTION
## Summary

- replace the nonexistent `mobius-ai` distribution with the published `mobius-onnx` package
- replace the retired `olive-ai[mobius-ai]` extra with explicit `olive-ai` and `mobius-onnx` dependencies
- update the Gemma 4 recipe installation documentation

## Validation

- targeted pre-commit hooks pass
- requirement resolution succeeds for `mobius-onnx` and `olive-ai>=0.13.0`
- repository search confirms no `mobius-ai` references remain