### PR TITLE
align qnn gpu models

### DIFF
--- a/.aitk/configs/checks.json
+++ b/.aitk/configs/checks.json
@@ -14,6 +14,6 @@
     "pathCheck": 1480,
     "requirementsCheck": 45,
     "templateCheck": 3,
-    "venvRequirementsCheck": 25,
+    "venvRequirementsCheck": 26,
     "winmlCopyCheck": 39
 }

--- a/.aitk/configs/model_list.json
+++ b/.aitk/configs/model_list.json
@@ -18,7 +18,7 @@
             "architecture": "Transformer",
             "status": "Ready",
             "relativePath": "microsoft-Phi-3.5-mini-instruct/aitk",
-            "version": 9,
+            "version": 10,
             "p0": true,
             "pipeline_tags": [
                 "text-generation"
@@ -193,7 +193,7 @@
             "architecture": "Transformer",
             "status": "Ready",
             "relativePath": "meta-llama-Llama-3.2-1B-Instruct/aitk",
-            "version": 9,
+            "version": 10,
             "p0": true,
             "pipeline_tags": [
                 "text-generation"
@@ -269,7 +269,7 @@
             "architecture": "Transformer",
             "status": "Ready",
             "relativePath": "Qwen-Qwen2.5-1.5B-Instruct/aitk",
-            "version": 8,
+            "version": 9,
             "p0": true,
             "pipeline_tags": [
                 "text-generation"
@@ -525,7 +525,7 @@
             "architecture": "Transformer",
             "status": "Ready",
             "relativePath": "meta-llama-Llama-3.1-8B-Instruct/aitk",
-            "version": 7,
+            "version": 8,
             "p0": false,
             "pipeline_tags": [
                 "text-generation"

--- a/.aitk/requirements/General/CUDA_py3.12.9-olive.txt
+++ b/.aitk/requirements/General/CUDA_py3.12.9-olive.txt
@@ -5,3 +5,4 @@ opentelemetry-semantic-conventions==0.65b0
 prompt-toolkit==3.0.53
 questionary==2.1.1
 wcwidth==0.8.2
+onnx-ir==0.1.12

--- a/.aitk/requirements/General/CUDA_py3.12.9-olive.txt
+++ b/.aitk/requirements/General/CUDA_py3.12.9-olive.txt
@@ -1,0 +1,7 @@
+olive-ai==0.13.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-semantic-conventions==0.65b0
+prompt-toolkit==3.0.53
+questionary==2.1.1
+wcwidth==0.8.2

--- a/.aitk/requirements/General/CUDA_py3.12.9-olive.txt
+++ b/.aitk/requirements/General/CUDA_py3.12.9-olive.txt
@@ -1,4 +1,4 @@
-olive-ai==0.13.0
+git+https://github.com/microsoft/Olive.git@20f407e38ac991838d23012a19089adf113241c7#egg=olive_ai
 opentelemetry-api==1.44.0
 opentelemetry-sdk==1.44.0
 opentelemetry-semantic-conventions==0.65b0

--- a/.aitk/scripts/sanitize/model_parameter.py
+++ b/.aitk/scripts/sanitize/model_parameter.py
@@ -750,7 +750,7 @@ class ModelParameter(BaseModelClass):
                     label,
                     refJson[OlivePropertyNames.Passes],
                     localJson[OlivePropertyNames.Passes],
-                    refFile,
+                    str(refPath),
                     ignoreConfig,
                 )
             return
@@ -780,9 +780,10 @@ class ModelParameter(BaseModelClass):
             return
         with open_ex(oliveFile, "r") as file:
             oliveFileJson = json.load(file)
-        label = "/".join(Path(self._file if self._file else "UNKNOWN").parts[-3:])
+        _file = Path(self._file if self._file else "UNKNOWN")
+        label = ("/".join(_file.parts[-3:-1])) + "/" + _file.stem
         self._diffOlivePasses(
-            label, oliveFileJson[OlivePropertyNames.Passes], oliveJson[OlivePropertyNames.Passes], oliveFileRef
+            label, oliveFileJson[OlivePropertyNames.Passes], oliveJson[OlivePropertyNames.Passes], str(oliveFile)
         )
 
     def checkExecutePatchPy(self):

--- a/Qwen-Qwen2.5-1.5B-Instruct/aitk/info.yml
+++ b/Qwen-Qwen2.5-1.5B-Instruct/aitk/info.yml
@@ -38,6 +38,9 @@ recipes:
         oliveFile: "QNN/config_gpu.json"
         isGPURequired: true
         requirements: General/CUDA_py3.12.9
+        executeRuntimeFeatures:
+          - olive
+          - AutoGptq
 aitk:
     modelInfo:
         id: "huggingface/Qwen/Qwen2.5-1.5B-Instruct"

--- a/Qwen-Qwen2.5-1.5B-Instruct/aitk/info.yml
+++ b/Qwen-Qwen2.5-1.5B-Instruct/aitk/info.yml
@@ -41,7 +41,7 @@ recipes:
 aitk:
     modelInfo:
         id: "huggingface/Qwen/Qwen2.5-1.5B-Instruct"
-        version: 8
+        version: 9
         groupId: "huggingface/Qwen/Qwen2.5-1.5B-Instruct"
         groupItemName: "1.5B"
         p0: true

--- a/Qwen-Qwen2.5-1.5B-Instruct/aitk/model_project.config
+++ b/Qwen-Qwen2.5-1.5B-Instruct/aitk/model_project.config
@@ -31,6 +31,6 @@
     ],
     "modelInfo": {
         "id": "huggingface/Qwen/Qwen2.5-1.5B-Instruct",
-        "version": 8
+        "version": 9
     }
 }

--- a/Qwen-Qwen2.5-1.5B-Instruct/aitk/qwen2_5_qnn_gpu_config.json
+++ b/Qwen-Qwen2.5-1.5B-Instruct/aitk/qwen2_5_qnn_gpu_config.json
@@ -87,16 +87,11 @@
             "type": "OnnxFloatToFloat16",
             "save_as_external_data": true
         },
-        "dtfs": {
-            "type": "DynamicToFixedShape",
-            "dim_param": ["past_sequence_length"],
-            "dim_value": [4096],
-            "save_as_external_data": true
-        },
         "st": {
             "type": "StaticLLM",
             "batch_size": 1,
-            "context_length": 128
+            "context_length": 128,
+            "update_genai_config": true
         }
     },
     "target": "target_system",

--- a/Qwen-Qwen2.5-1.5B-Instruct/aitk/qwen2_5_qnn_gpu_config.json
+++ b/Qwen-Qwen2.5-1.5B-Instruct/aitk/qwen2_5_qnn_gpu_config.json
@@ -76,14 +76,27 @@
                 },
                 {
                     "surgeon": "AttentionMaskToSequenceLengths"
+                },
+                {
+                    "surgeon": "SimplifiedLayerNormToRMSNorm"
                 }
             ],
+            "save_as_external_data": true
+        },
+        "fp16": {
+            "type": "OnnxFloatToFloat16",
+            "save_as_external_data": true
+        },
+        "dtfs": {
+            "type": "DynamicToFixedShape",
+            "dim_param": ["past_sequence_length"],
+            "dim_value": [4096],
             "save_as_external_data": true
         },
         "st": {
             "type": "StaticLLM",
             "batch_size": 1,
-            "context_length": 1
+            "context_length": 128
         }
     },
     "target": "target_system",

--- a/Qwen-Qwen2.5-1.5B-Instruct/aitk/qwen2_5_qnn_gpu_config.json.config
+++ b/Qwen-Qwen2.5-1.5B-Instruct/aitk/qwen2_5_qnn_gpu_config.json.config
@@ -13,6 +13,7 @@
         "executeRequirement": "General/CUDA_py3.12.9"
     },
     "executeRuntimeFeatures": [
+        "olive",
         "AutoGptq"
     ],
     "runtime": {

--- a/meta-llama-Llama-3.1-8B-Instruct/aitk/info.yml
+++ b/meta-llama-Llama-3.1-8B-Instruct/aitk/info.yml
@@ -14,6 +14,9 @@ recipes:
         oliveFile: "../meta-llama-Llama-3.2-1B-Instruct/QNN/config_gpu.json"
         isGPURequired: true
         requirements: General/CUDA_py3.12.9
+        executeRuntimeFeatures:
+          - olive
+          - AutoGptq
     - file: "llama3_1_vitis_ai_config.json"
       device: npu
       ep: VitisAIExecutionProvider

--- a/meta-llama-Llama-3.1-8B-Instruct/aitk/info.yml
+++ b/meta-llama-Llama-3.1-8B-Instruct/aitk/info.yml
@@ -42,5 +42,5 @@ recipes:
 aitk:
     modelInfo:
         id: "huggingface/meta-llama/Llama-3.1-8B-Instruct"
-        version: 7
+        version: 8
         p0: false

--- a/meta-llama-Llama-3.1-8B-Instruct/aitk/llama3_1_qnn_gpu.json
+++ b/meta-llama-Llama-3.1-8B-Instruct/aitk/llama3_1_qnn_gpu.json
@@ -87,16 +87,11 @@
             "type": "OnnxFloatToFloat16",
             "save_as_external_data": true
         },
-        "dtfs": {
-            "type": "DynamicToFixedShape",
-            "dim_param": ["past_sequence_length"],
-            "dim_value": [4096],
-            "save_as_external_data": true
-        },
         "st": {
             "type": "StaticLLM",
             "batch_size": 1,
-            "context_length": 128
+            "context_length": 128,
+            "update_genai_config": true
         }
     },
     "target": "target_system",

--- a/meta-llama-Llama-3.1-8B-Instruct/aitk/llama3_1_qnn_gpu.json
+++ b/meta-llama-Llama-3.1-8B-Instruct/aitk/llama3_1_qnn_gpu.json
@@ -76,14 +76,27 @@
                 },
                 {
                     "surgeon": "AttentionMaskToSequenceLengths"
+                },
+                {
+                    "surgeon": "SimplifiedLayerNormToRMSNorm"
                 }
             ],
+            "save_as_external_data": true
+        },
+        "fp16": {
+            "type": "OnnxFloatToFloat16",
+            "save_as_external_data": true
+        },
+        "dtfs": {
+            "type": "DynamicToFixedShape",
+            "dim_param": ["past_sequence_length"],
+            "dim_value": [4096],
             "save_as_external_data": true
         },
         "st": {
             "type": "StaticLLM",
             "batch_size": 1,
-            "context_length": 1
+            "context_length": 128
         }
     },
     "target": "target_system",

--- a/meta-llama-Llama-3.1-8B-Instruct/aitk/llama3_1_qnn_gpu.json.config
+++ b/meta-llama-Llama-3.1-8B-Instruct/aitk/llama3_1_qnn_gpu.json.config
@@ -13,6 +13,7 @@
         "executeRequirement": "General/CUDA_py3.12.9"
     },
     "executeRuntimeFeatures": [
+        "olive",
         "AutoGptq"
     ],
     "runtime": {

--- a/meta-llama-Llama-3.1-8B-Instruct/aitk/model_project.config
+++ b/meta-llama-Llama-3.1-8B-Instruct/aitk/model_project.config
@@ -31,6 +31,6 @@
     ],
     "modelInfo": {
         "id": "huggingface/meta-llama/Llama-3.1-8B-Instruct",
-        "version": 7
+        "version": 8
     }
 }

--- a/meta-llama-Llama-3.2-1B-Instruct/aitk/info.yml
+++ b/meta-llama-Llama-3.2-1B-Instruct/aitk/info.yml
@@ -38,6 +38,9 @@ recipes:
         oliveFile: "QNN/config_gpu.json"
         isGPURequired: true
         requirements: General/CUDA_py3.12.9
+        executeRuntimeFeatures:
+          - olive
+          - AutoGptq
 aitk:
     modelInfo:
         id: "huggingface/meta-llama/Llama-3.2-1B-Instruct"

--- a/meta-llama-Llama-3.2-1B-Instruct/aitk/info.yml
+++ b/meta-llama-Llama-3.2-1B-Instruct/aitk/info.yml
@@ -41,5 +41,5 @@ recipes:
 aitk:
     modelInfo:
         id: "huggingface/meta-llama/Llama-3.2-1B-Instruct"
-        version: 9
+        version: 10
         p0: true

--- a/meta-llama-Llama-3.2-1B-Instruct/aitk/llama3_2_qnn_gpu_config.json
+++ b/meta-llama-Llama-3.2-1B-Instruct/aitk/llama3_2_qnn_gpu_config.json
@@ -87,16 +87,11 @@
             "type": "OnnxFloatToFloat16",
             "save_as_external_data": true
         },
-        "dtfs": {
-            "type": "DynamicToFixedShape",
-            "dim_param": ["past_sequence_length"],
-            "dim_value": [4096],
-            "save_as_external_data": true
-        },
         "st": {
             "type": "StaticLLM",
             "batch_size": 1,
-            "context_length": 128
+            "context_length": 128,
+            "update_genai_config": true
         }
     },
     "target": "target_system",

--- a/meta-llama-Llama-3.2-1B-Instruct/aitk/llama3_2_qnn_gpu_config.json
+++ b/meta-llama-Llama-3.2-1B-Instruct/aitk/llama3_2_qnn_gpu_config.json
@@ -76,14 +76,27 @@
                 },
                 {
                     "surgeon": "AttentionMaskToSequenceLengths"
+                },
+                {
+                    "surgeon": "SimplifiedLayerNormToRMSNorm"
                 }
             ],
+            "save_as_external_data": true
+        },
+        "fp16": {
+            "type": "OnnxFloatToFloat16",
+            "save_as_external_data": true
+        },
+        "dtfs": {
+            "type": "DynamicToFixedShape",
+            "dim_param": ["past_sequence_length"],
+            "dim_value": [4096],
             "save_as_external_data": true
         },
         "st": {
             "type": "StaticLLM",
             "batch_size": 1,
-            "context_length": 1
+            "context_length": 128
         }
     },
     "target": "target_system",

--- a/meta-llama-Llama-3.2-1B-Instruct/aitk/llama3_2_qnn_gpu_config.json.config
+++ b/meta-llama-Llama-3.2-1B-Instruct/aitk/llama3_2_qnn_gpu_config.json.config
@@ -13,6 +13,7 @@
         "executeRequirement": "General/CUDA_py3.12.9"
     },
     "executeRuntimeFeatures": [
+        "olive",
         "AutoGptq"
     ],
     "runtime": {

--- a/meta-llama-Llama-3.2-1B-Instruct/aitk/model_project.config
+++ b/meta-llama-Llama-3.2-1B-Instruct/aitk/model_project.config
@@ -31,6 +31,6 @@
     ],
     "modelInfo": {
         "id": "huggingface/meta-llama/Llama-3.2-1B-Instruct",
-        "version": 9
+        "version": 10
     }
 }

--- a/microsoft-Phi-3.5-mini-instruct/aitk/info.yml
+++ b/microsoft-Phi-3.5-mini-instruct/aitk/info.yml
@@ -38,6 +38,9 @@ recipes:
         oliveFile: "QNN/config_gpu.json"
         isGPURequired: true
         requirements: General/CUDA_py3.12.9
+        executeRuntimeFeatures:
+          - olive
+          - AutoGptq
 aitk:
     modelInfo:
         id: "huggingface/microsoft/Phi-3.5-mini-instruct"

--- a/microsoft-Phi-3.5-mini-instruct/aitk/info.yml
+++ b/microsoft-Phi-3.5-mini-instruct/aitk/info.yml
@@ -41,5 +41,5 @@ recipes:
 aitk:
     modelInfo:
         id: "huggingface/microsoft/Phi-3.5-mini-instruct"
-        version: 9
+        version: 10
         p0: true

--- a/microsoft-Phi-3.5-mini-instruct/aitk/model_project.config
+++ b/microsoft-Phi-3.5-mini-instruct/aitk/model_project.config
@@ -31,6 +31,6 @@
     ],
     "modelInfo": {
         "id": "huggingface/microsoft/Phi-3.5-mini-instruct",
-        "version": 9
+        "version": 10
     }
 }

--- a/microsoft-Phi-3.5-mini-instruct/aitk/phi3_5_qnn_gpu_config.json
+++ b/microsoft-Phi-3.5-mini-instruct/aitk/phi3_5_qnn_gpu_config.json
@@ -87,16 +87,11 @@
             "type": "OnnxFloatToFloat16",
             "save_as_external_data": true
         },
-        "dtfs": {
-            "type": "DynamicToFixedShape",
-            "dim_param": ["past_sequence_length"],
-            "dim_value": [4096],
-            "save_as_external_data": true
-        },
         "st": {
             "type": "StaticLLM",
             "batch_size": 1,
-            "context_length": 128
+            "context_length": 128,
+            "update_genai_config": true
         }
     },
     "target": "target_system",

--- a/microsoft-Phi-3.5-mini-instruct/aitk/phi3_5_qnn_gpu_config.json
+++ b/microsoft-Phi-3.5-mini-instruct/aitk/phi3_5_qnn_gpu_config.json
@@ -76,14 +76,27 @@
                 },
                 {
                     "surgeon": "AttentionMaskToSequenceLengths"
+                },
+                {
+                    "surgeon": "SimplifiedLayerNormToRMSNorm"
                 }
             ],
+            "save_as_external_data": true
+        },
+        "fp16": {
+            "type": "OnnxFloatToFloat16",
+            "save_as_external_data": true
+        },
+        "dtfs": {
+            "type": "DynamicToFixedShape",
+            "dim_param": ["past_sequence_length"],
+            "dim_value": [4096],
             "save_as_external_data": true
         },
         "st": {
             "type": "StaticLLM",
             "batch_size": 1,
-            "context_length": 1
+            "context_length": 128
         }
     },
     "target": "target_system",

--- a/microsoft-Phi-3.5-mini-instruct/aitk/phi3_5_qnn_gpu_config.json.config
+++ b/microsoft-Phi-3.5-mini-instruct/aitk/phi3_5_qnn_gpu_config.json.config
@@ -13,6 +13,7 @@
         "executeRequirement": "General/CUDA_py3.12.9"
     },
     "executeRuntimeFeatures": [
+        "olive",
         "AutoGptq"
     ],
     "runtime": {


### PR DESCRIPTION
Remove static to allow dynamic max_length and it is faster ?

Tested on 2.2480.49.0

qwen

Total tokens generated: 72
Average time per token: 0.0470 seconds
Tokens per second: 21.30

llama 1b

Total tokens generated: 64
Average time per token: 0.0406 seconds
Tokens per second: 24.60

phi

Total tokens generated: 72
Average time per token: 0.1033 seconds
Tokens per second: 9.68

working on next ep release, but not tested one
