### PR TITLE
Update SelectiveMixedPrecision heuristic names

### DIFF
--- a/Qwen-Qwen2.5-1.5B-Instruct/olive/mixed.json
+++ b/Qwen-Qwen2.5-1.5B-Instruct/olive/mixed.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_down"
+            "algorithm": "high_precision_mlp"
         },
         "g": {
             "type": "gptq",

--- a/Qwen-Qwen2.5-1.5B-Instruct/olive/mixed.json
+++ b/Qwen-Qwen2.5-1.5B-Instruct/olive/mixed.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "high_precision_mlp"
+            "algorithm": "high_precision_mlp_down"
         },
         "g": {
             "type": "gptq",

--- a/Qwen-Qwen2.5-1.5B-Instruct/olive/requirements.txt
+++ b/Qwen-Qwen2.5-1.5B-Instruct/olive/requirements.txt
@@ -1,4 +1,4 @@
 lm_eval
-olive-ai
+git+https://github.com/microsoft/Olive
 onnxruntime-genai-cuda
 tabulate

--- a/Qwen-Qwen2.5-1.5B-Instruct/olive/requirements.txt
+++ b/Qwen-Qwen2.5-1.5B-Instruct/olive/requirements.txt
@@ -1,4 +1,4 @@
+git+https://github.com/microsoft/Olive.git@main
 lm_eval
-git+https://github.com/microsoft/Olive
 onnxruntime-genai-cuda
 tabulate

--- a/Qwen-Qwen3-14B/cpu/Qwen-Qwen3-14B_cpu_int4.json
+++ b/Qwen-Qwen3-14B/cpu/Qwen-Qwen3-14B_cpu_int4.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "high_precision_mlp_qkv"
+            "algorithm": "high_precision_mlp_down_qkv"
         },
         "g": {
             "type": "gptq",

--- a/Qwen-Qwen3-14B/cpu/Qwen-Qwen3-14B_cpu_int4.json
+++ b/Qwen-Qwen3-14B/cpu/Qwen-Qwen3-14B_cpu_int4.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_mixed"
+            "algorithm": "high_precision_mlp_qkv"
         },
         "g": {
             "type": "gptq",

--- a/Qwen-Qwen3-14B/cpu/README.md
+++ b/Qwen-Qwen3-14B/cpu/README.md
@@ -18,8 +18,8 @@ This folder contains Olive recipes for optimizing Qwen-Qwen3-14B targeting the C
    - olive run --config Qwen-Qwen3-14B_cpu_int4.json
 
 Additional notes:
-- Pipeline: `SelectiveMixedPrecision` (k_quant_mixed) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
-- Uses `k_quant_mixed` instead of `kld_gradient` because gradient-based sensitivity
+- Pipeline: `SelectiveMixedPrecision` (high_precision_mlp_qkv) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
+- Uses `high_precision_mlp_qkv` instead of `kld_gradient` because gradient-based sensitivity
   estimation exceeds the 80 GB per-GPU memory limit for the 14B model.
 - GPTQ group size: 128
 - Runs purely on CPU; no GPU required.

--- a/Qwen-Qwen3-14B/cpu/README.md
+++ b/Qwen-Qwen3-14B/cpu/README.md
@@ -18,8 +18,8 @@ This folder contains Olive recipes for optimizing Qwen-Qwen3-14B targeting the C
    - olive run --config Qwen-Qwen3-14B_cpu_int4.json
 
 Additional notes:
-- Pipeline: `SelectiveMixedPrecision` (high_precision_mlp_qkv) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
-- Uses `high_precision_mlp_qkv` instead of `kld_gradient` because gradient-based sensitivity
+- Pipeline: `SelectiveMixedPrecision` (high_precision_mlp_down_qkv) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
+- Uses `high_precision_mlp_down_qkv` instead of `kld_gradient` because gradient-based sensitivity
   estimation exceeds the 80 GB per-GPU memory limit for the 14B model.
 - GPTQ group size: 128
 - Runs purely on CPU; no GPU required.

--- a/Qwen-Qwen3-14B/cuda/Qwen-Qwen3-14B_cuda_int4.json
+++ b/Qwen-Qwen3-14B/cuda/Qwen-Qwen3-14B_cuda_int4.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "high_precision_mlp_qkv"
+            "algorithm": "high_precision_mlp_down_qkv"
         },
         "g": {
             "type": "gptq",

--- a/Qwen-Qwen3-14B/cuda/Qwen-Qwen3-14B_cuda_int4.json
+++ b/Qwen-Qwen3-14B/cuda/Qwen-Qwen3-14B_cuda_int4.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_mixed"
+            "algorithm": "high_precision_mlp_qkv"
         },
         "g": {
             "type": "gptq",

--- a/Qwen-Qwen3-14B/cuda/README.md
+++ b/Qwen-Qwen3-14B/cuda/README.md
@@ -18,8 +18,8 @@ This folder contains Olive recipes for optimizing Qwen-Qwen3-14B targeting the C
    - olive run --config Qwen-Qwen3-14B_cuda_int4.json
 
 Additional notes:
-- Pipeline: `SelectiveMixedPrecision` (high_precision_mlp_qkv) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
-- Uses `high_precision_mlp_qkv` instead of `kld_gradient` because gradient-based sensitivity
+- Pipeline: `SelectiveMixedPrecision` (high_precision_mlp_down_qkv) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
+- Uses `high_precision_mlp_down_qkv` instead of `kld_gradient` because gradient-based sensitivity
   estimation exceeds the 80 GB per-GPU memory limit for the 14B model.
 - GPTQ group size: 128
 - Requires NVIDIA GPU with CUDA support.

--- a/Qwen-Qwen3-14B/cuda/README.md
+++ b/Qwen-Qwen3-14B/cuda/README.md
@@ -18,8 +18,8 @@ This folder contains Olive recipes for optimizing Qwen-Qwen3-14B targeting the C
    - olive run --config Qwen-Qwen3-14B_cuda_int4.json
 
 Additional notes:
-- Pipeline: `SelectiveMixedPrecision` (k_quant_mixed) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
-- Uses `k_quant_mixed` instead of `kld_gradient` because gradient-based sensitivity
+- Pipeline: `SelectiveMixedPrecision` (high_precision_mlp_qkv) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
+- Uses `high_precision_mlp_qkv` instead of `kld_gradient` because gradient-based sensitivity
   estimation exceeds the 80 GB per-GPU memory limit for the 14B model.
 - GPTQ group size: 128
 - Requires NVIDIA GPU with CUDA support.

--- a/Qwen-Qwen3-14B/webgpu/Qwen-Qwen3-14B_webgpu_int4.json
+++ b/Qwen-Qwen3-14B/webgpu/Qwen-Qwen3-14B_webgpu_int4.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "high_precision_mlp_qkv"
+            "algorithm": "high_precision_mlp_down_qkv"
         },
         "g": {
             "type": "gptq",

--- a/Qwen-Qwen3-14B/webgpu/Qwen-Qwen3-14B_webgpu_int4.json
+++ b/Qwen-Qwen3-14B/webgpu/Qwen-Qwen3-14B_webgpu_int4.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_mixed"
+            "algorithm": "high_precision_mlp_qkv"
         },
         "g": {
             "type": "gptq",

--- a/Qwen-Qwen3-14B/webgpu/README.md
+++ b/Qwen-Qwen3-14B/webgpu/README.md
@@ -18,8 +18,8 @@ This folder contains Olive recipes for optimizing Qwen-Qwen3-14B targeting the W
    - olive run --config Qwen-Qwen3-14B_webgpu_int4.json
 
 Additional notes:
-- Pipeline: `SelectiveMixedPrecision` (high_precision_mlp_qkv) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
-- Uses `high_precision_mlp_qkv` instead of `kld_gradient` because gradient-based sensitivity
+- Pipeline: `SelectiveMixedPrecision` (high_precision_mlp_down_qkv) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
+- Uses `high_precision_mlp_down_qkv` instead of `kld_gradient` because gradient-based sensitivity
   estimation exceeds the 80 GB per-GPU memory limit for the 14B model.
 - GPTQ group size: 32
 - WebGPU enables GPU-accelerated inference in web browsers.

--- a/Qwen-Qwen3-14B/webgpu/README.md
+++ b/Qwen-Qwen3-14B/webgpu/README.md
@@ -18,8 +18,8 @@ This folder contains Olive recipes for optimizing Qwen-Qwen3-14B targeting the W
    - olive run --config Qwen-Qwen3-14B_webgpu_int4.json
 
 Additional notes:
-- Pipeline: `SelectiveMixedPrecision` (k_quant_mixed) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
-- Uses `k_quant_mixed` instead of `kld_gradient` because gradient-based sensitivity
+- Pipeline: `SelectiveMixedPrecision` (high_precision_mlp_qkv) → `GPTQ` → `RTN` (8-bit lm_head/embeddings) → `ModelBuilder`
+- Uses `high_precision_mlp_qkv` instead of `kld_gradient` because gradient-based sensitivity
   estimation exceeds the 80 GB per-GPU memory limit for the 14B model.
 - GPTQ group size: 32
 - WebGPU enables GPU-accelerated inference in web browsers.

--- a/deepseek-ai-DeepSeek-R1-Distill-Qwen-1.5B/olive/mixed.json
+++ b/deepseek-ai-DeepSeek-R1-Distill-Qwen-1.5B/olive/mixed.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "high_precision_mlp_qkv"
+            "algorithm": "high_precision_mlp_down_qkv"
         },
         "g": {
             "type": "gptq",

--- a/deepseek-ai-DeepSeek-R1-Distill-Qwen-1.5B/olive/mixed.json
+++ b/deepseek-ai-DeepSeek-R1-Distill-Qwen-1.5B/olive/mixed.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_mixed"
+            "algorithm": "high_precision_mlp_qkv"
         },
         "g": {
             "type": "gptq",

--- a/deepseek-ai-DeepSeek-R1-Distill-Qwen-1.5B/olive/requirements.txt
+++ b/deepseek-ai-DeepSeek-R1-Distill-Qwen-1.5B/olive/requirements.txt
@@ -1,4 +1,4 @@
 lm_eval
-olive-ai
+git+https://github.com/microsoft/Olive
 onnxruntime-genai-cuda
 tabulate

--- a/deepseek-ai-DeepSeek-R1-Distill-Qwen-1.5B/olive/requirements.txt
+++ b/deepseek-ai-DeepSeek-R1-Distill-Qwen-1.5B/olive/requirements.txt
@@ -1,4 +1,4 @@
+git+https://github.com/microsoft/Olive.git@main
 lm_eval
-git+https://github.com/microsoft/Olive
 onnxruntime-genai-cuda
 tabulate

--- a/meta-llama-Llama-3.2-1B-Instruct/olive/mixed.json
+++ b/meta-llama-Llama-3.2-1B-Instruct/olive/mixed.json
@@ -23,7 +23,7 @@
         },
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_down"
+            "algorithm": "high_precision_mlp"
         },
         "g": {
             "type": "gptq",

--- a/meta-llama-Llama-3.2-1B-Instruct/olive/mixed.json
+++ b/meta-llama-Llama-3.2-1B-Instruct/olive/mixed.json
@@ -23,7 +23,7 @@
         },
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "high_precision_mlp"
+            "algorithm": "high_precision_mlp_down"
         },
         "g": {
             "type": "gptq",

--- a/meta-llama-Llama-3.2-1B-Instruct/olive/requirements-mixed.txt
+++ b/meta-llama-Llama-3.2-1B-Instruct/olive/requirements-mixed.txt
@@ -1,4 +1,4 @@
 lm_eval
-olive-ai
+git+https://github.com/microsoft/Olive
 onnxruntime-genai-cuda
 tabulate

--- a/meta-llama-Llama-3.2-1B-Instruct/olive/requirements-mixed.txt
+++ b/meta-llama-Llama-3.2-1B-Instruct/olive/requirements-mixed.txt
@@ -1,4 +1,4 @@
+git+https://github.com/microsoft/Olive.git@main
 lm_eval
-git+https://github.com/microsoft/Olive
 onnxruntime-genai-cuda
 tabulate

--- a/microsoft-Phi-3.5-mini-instruct/olive/mixed.json
+++ b/microsoft-Phi-3.5-mini-instruct/olive/mixed.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_down"
+            "algorithm": "high_precision_mlp"
         },
         "g": {
             "type": "gptq",

--- a/microsoft-Phi-3.5-mini-instruct/olive/mixed.json
+++ b/microsoft-Phi-3.5-mini-instruct/olive/mixed.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "high_precision_mlp"
+            "algorithm": "high_precision_mlp_down"
         },
         "g": {
             "type": "gptq",

--- a/microsoft-Phi-3.5-mini-instruct/olive/requirements.txt
+++ b/microsoft-Phi-3.5-mini-instruct/olive/requirements.txt
@@ -1,4 +1,4 @@
 lm_eval
-olive-ai
+git+https://github.com/microsoft/Olive
 onnxruntime-genai-cuda
 tabulate

--- a/microsoft-Phi-3.5-mini-instruct/olive/requirements.txt
+++ b/microsoft-Phi-3.5-mini-instruct/olive/requirements.txt
@@ -1,4 +1,4 @@
+git+https://github.com/microsoft/Olive.git@main
 lm_eval
-git+https://github.com/microsoft/Olive
 onnxruntime-genai-cuda
 tabulate

--- a/microsoft-Phi-4-mini-instruct/olive/mixed-tied.json
+++ b/microsoft-Phi-4-mini-instruct/olive/mixed-tied.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "high_precision_mlp_qkv"
+            "algorithm": "high_precision_mlp_down_qkv"
         },
         "g": {
             "type": "gptq",

--- a/microsoft-Phi-4-mini-instruct/olive/mixed-tied.json
+++ b/microsoft-Phi-4-mini-instruct/olive/mixed-tied.json
@@ -20,7 +20,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_mixed"
+            "algorithm": "high_precision_mlp_qkv"
         },
         "g": {
             "type": "gptq",

--- a/microsoft-Phi-4-mini-instruct/olive/mixed.json
+++ b/microsoft-Phi-4-mini-instruct/olive/mixed.json
@@ -23,7 +23,7 @@
         },
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "high_precision_mlp_qkv"
+            "algorithm": "high_precision_mlp_down_qkv"
         },
         "g": {
             "type": "gptq",

--- a/microsoft-Phi-4-mini-instruct/olive/mixed.json
+++ b/microsoft-Phi-4-mini-instruct/olive/mixed.json
@@ -23,7 +23,7 @@
         },
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_mixed"
+            "algorithm": "high_precision_mlp_qkv"
         },
         "g": {
             "type": "gptq",

--- a/nvidia-Mistral-NeMo-12B-Instruct/cpu/nvidia-Mistral-NeMo-12B-Instruct_cpu_int4.json
+++ b/nvidia-Mistral-NeMo-12B-Instruct/cpu/nvidia-Mistral-NeMo-12B-Instruct_cpu_int4.json
@@ -22,7 +22,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_last"
+            "algorithm": "high_precision_lm_head"
         },
         "g": {
             "type": "gptq",

--- a/nvidia-Mistral-NeMo-12B-Instruct/cpu/nvidia-Mistral-NeMo-12B-Instruct_cpu_int4_with_eval.json
+++ b/nvidia-Mistral-NeMo-12B-Instruct/cpu/nvidia-Mistral-NeMo-12B-Instruct_cpu_int4_with_eval.json
@@ -22,7 +22,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_last"
+            "algorithm": "high_precision_lm_head"
         },
         "g": {
             "type": "gptq",

--- a/nvidia-Mistral-NeMo-12B-Instruct/cpu/requirements.txt
+++ b/nvidia-Mistral-NeMo-12B-Instruct/cpu/requirements.txt
@@ -1,7 +1,7 @@
 accelerate
 datasets
 lm-eval
-olive-ai
+git+https://github.com/microsoft/Olive
 onnxruntime-genai
 sentencepiece
 tiktoken

--- a/nvidia-Mistral-NeMo-12B-Instruct/cpu/requirements.txt
+++ b/nvidia-Mistral-NeMo-12B-Instruct/cpu/requirements.txt
@@ -1,7 +1,7 @@
 accelerate
 datasets
+git+https://github.com/microsoft/Olive.git@main
 lm-eval
-git+https://github.com/microsoft/Olive
 onnxruntime-genai
 sentencepiece
 tiktoken

--- a/nvidia-Mistral-NeMo-12B-Instruct/cuda/nvidia-Mistral-NeMo-12B-Instruct_cuda_int4.json
+++ b/nvidia-Mistral-NeMo-12B-Instruct/cuda/nvidia-Mistral-NeMo-12B-Instruct_cuda_int4.json
@@ -22,7 +22,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_last"
+            "algorithm": "high_precision_lm_head"
         },
         "g": {
             "type": "gptq",

--- a/nvidia-Mistral-NeMo-12B-Instruct/cuda/nvidia-Mistral-NeMo-12B-Instruct_cuda_int4_with_eval.json
+++ b/nvidia-Mistral-NeMo-12B-Instruct/cuda/nvidia-Mistral-NeMo-12B-Instruct_cuda_int4_with_eval.json
@@ -22,7 +22,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_last"
+            "algorithm": "high_precision_lm_head"
         },
         "g": {
             "type": "gptq",

--- a/nvidia-Mistral-NeMo-12B-Instruct/cuda/requirements.txt
+++ b/nvidia-Mistral-NeMo-12B-Instruct/cuda/requirements.txt
@@ -1,7 +1,7 @@
 accelerate
 datasets
+git+https://github.com/microsoft/Olive.git@main
 lm-eval
-git+https://github.com/microsoft/Olive
 onnxruntime-genai-cuda
 onnxruntime-gpu
 sentencepiece

--- a/nvidia-Mistral-NeMo-12B-Instruct/cuda/requirements.txt
+++ b/nvidia-Mistral-NeMo-12B-Instruct/cuda/requirements.txt
@@ -1,7 +1,7 @@
 accelerate
 datasets
 lm-eval
-olive-ai
+git+https://github.com/microsoft/Olive
 onnxruntime-genai-cuda
 onnxruntime-gpu
 sentencepiece

--- a/nvidia-Mistral-NeMo-12B-Instruct/webgpu/nvidia-Mistral-NeMo-12B-Instruct_webgpu_int4.json
+++ b/nvidia-Mistral-NeMo-12B-Instruct/webgpu/nvidia-Mistral-NeMo-12B-Instruct_webgpu_int4.json
@@ -22,7 +22,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_last"
+            "algorithm": "high_precision_lm_head"
         },
         "g": {
             "type": "gptq",

--- a/nvidia-Mistral-NeMo-12B-Instruct/webgpu/nvidia-Mistral-NeMo-12B-Instruct_webgpu_int4_with_eval.json
+++ b/nvidia-Mistral-NeMo-12B-Instruct/webgpu/nvidia-Mistral-NeMo-12B-Instruct_webgpu_int4_with_eval.json
@@ -22,7 +22,7 @@
     "passes": {
         "s": {
             "type": "SelectiveMixedPrecision",
-            "algorithm": "k_quant_last"
+            "algorithm": "high_precision_lm_head"
         },
         "g": {
             "type": "gptq",

--- a/nvidia-Mistral-NeMo-12B-Instruct/webgpu/requirements.txt
+++ b/nvidia-Mistral-NeMo-12B-Instruct/webgpu/requirements.txt
@@ -1,8 +1,8 @@
 --pre
 accelerate
 datasets
+git+https://github.com/microsoft/Olive.git@main
 lm-eval
-git+https://github.com/microsoft/Olive
 onnxruntime-genai
 onnxruntime-webgpu
 sentencepiece

--- a/nvidia-Mistral-NeMo-12B-Instruct/webgpu/requirements.txt
+++ b/nvidia-Mistral-NeMo-12B-Instruct/webgpu/requirements.txt
@@ -2,7 +2,7 @@
 accelerate
 datasets
 lm-eval
-olive-ai
+git+https://github.com/microsoft/Olive
 onnxruntime-genai
 onnxruntime-webgpu
 sentencepiece


### PR DESCRIPTION
## Summary

- Migrate SelectiveMixedPrecision recipes from deprecated `k_quant_*` algorithm names to `high_precision_lm_head`, `high_precision_mlp_down`, and `high_precision_mlp_down_qkv`.
- Update Qwen3-14B documentation to use the canonical names.
- Install Olive from `microsoft/Olive` main for affected recipes so the canonical names do not depend on a future PyPI release.
- Leave `ModelBuilder.int4_algo_config` values unchanged because those are independent ORT GenAI algorithm names.

## Dependency

Depends on microsoft/Olive#2643. Merge that PR first; the canonical algorithm names are not recognized by older Olive releases.