### PR TITLE
Support DeepStack (Qwen3-VL) export

### DIFF
--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/codes/modeling_qwen3_vl.py
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/codes/modeling_qwen3_vl.py
@@ -498,8 +498,13 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
         )
         cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
 
-        # NOTE: DeepStack features are not exported separately for ONNX.
-        # They are handled by the text model builder (ModelBuilder) in the text.json pass.
+        # DeepStack: capture visual features at the configured layers and run them
+        # through their per-index patch mergers. Return them SEPARATELY (not folded
+        # into the merged features) so the text decoder can inject each into its
+        # corresponding early layer (feature[i] -> decoder layer i), matching HF's
+        # layer-wise deepstack injection exactly instead of the input-embedding
+        # approximation.
+        deepstack_feats = []
         for layer_num, blk in enumerate(self.blocks):
             hidden_states = blk(
                 hidden_states,
@@ -507,10 +512,14 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
                 position_embeddings=position_embeddings,
                 **kwargs,
             )
+            if layer_num in self.deepstack_visual_indexes:
+                ds_idx = self.deepstack_visual_indexes.index(layer_num)
+                deepstack_feats.append(self.deepstack_merger_list[ds_idx](hidden_states))
 
         hidden_states = self.merger(hidden_states)
 
-        return hidden_states
+        # image_features + one output per deepstack index (3 for case2: indexes [5, 11, 17])
+        return (hidden_states, *deepstack_feats)
 
 
 @dataclass
@@ -873,28 +882,38 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
     def get_image_features(self, pixel_values: torch.FloatTensor, image_grid_thw: Optional[torch.LongTensor] = None):
         """
         Encodes images into continuous embeddings that can be forwarded to the language model.
-        For ONNX export, only returns the main merged features (no deepstack).
+
+        Returns a tuple `(image_features, deepstack_0, deepstack_1, deepstack_2)`. vision.onnx is
+        exported single-image (VisionState loops per-image in C++), so no per-image split is needed;
+        the DeepStack features are returned separately for per-layer injection in the text decoder.
         """
         pixel_values = pixel_values.type(self.visual.dtype)
-        image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
-        # Return the full concatenated feature tensor.  Callers that need per-image
-        # slices can split offline using:
-        #   sizes = (image_grid_thw.prod(-1) // spatial_merge_size**2).tolist()
-        # The ONNX model outputs a single tensor; the genai runtime handles per-image
-        # splitting using image_grid_thw.  Removing .tolist() and torch.split here
-        # allows image_grid_thw.shape[0] to remain symbolic during export.
-        return image_embeds
+        image_features, *deepstack_feats = self.visual(pixel_values, grid_thw=image_grid_thw)
+        return (image_features, *deepstack_feats)
 
-    def get_fused_input_embeddings(self, input_ids, image_features=None):
+    def get_fused_input_embeddings(
+        self,
+        input_ids,
+        image_features=None,
+        deepstack_features_0=None,
+        deepstack_features_1=None,
+        deepstack_features_2=None,
+    ):
         """
-        Fuses the input embeddings from the language model with the image features.
+        Fuses the input embeddings from the language model with the image features, and scatters
+        the three per-token DeepStack features into full-length (batch, seq, hidden) tensors so the
+        text decoder can inject them with plain static Adds at layers 0/1/2.
 
         Args:
             input_ids (`torch.LongTensor`): The input IDs for the language model.
             image_features (`torch.FloatTensor`, optional): The image features to fuse with the input embeddings.
+            deepstack_features_0/1/2 (`torch.FloatTensor`, optional): per-token DeepStack features
+                (same shape as image_features) for decoder layers 0/1/2.
 
         Returns:
-            `torch.FloatTensor`: The fused input embeddings.
+            tuple `(inputs_embeds, deepstack_0_full, deepstack_1_full, deepstack_2_full)`, where each
+            `deepstack_i_full` is a zero tensor with `deepstack_features_i` scattered into image-token
+            positions (or all-zeros during generation when there are no image tokens).
         """
         def true_fn_for_input_ids(input_ids):
             special_image_mask = input_ids == self.config.image_token_id
@@ -913,24 +932,32 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
 
         inputs_embeds = self.language_model.get_input_embeddings()(llm_input_ids)
 
-        def image_features_is_none(inputs_embeds, image_features=None):
-            return inputs_embeds
+        def image_features_is_none(inputs_embeds, image_features, ds0, ds1, ds2):
+            zeros = torch.zeros_like(inputs_embeds)
+            return inputs_embeds, zeros, zeros.clone(), zeros.clone()
 
-        def image_features_is_not_none(inputs_embeds, image_features=None):
+        def image_features_is_not_none(inputs_embeds, image_features, ds0, ds1, ds2):
             special_image_mask = (llm_input_ids == self.config.image_token_id).unsqueeze(-1)
             special_image_mask = special_image_mask.expand_as(inputs_embeds).to(inputs_embeds.device)
             image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
             inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
-            return inputs_embeds
 
-        inputs_embeds = torch.cond(
+            ds0 = ds0.to(inputs_embeds.device, inputs_embeds.dtype)
+            ds1 = ds1.to(inputs_embeds.device, inputs_embeds.dtype)
+            ds2 = ds2.to(inputs_embeds.device, inputs_embeds.dtype)
+            ds0_full = torch.zeros_like(inputs_embeds).masked_scatter(special_image_mask, ds0)
+            ds1_full = torch.zeros_like(inputs_embeds).masked_scatter(special_image_mask, ds1)
+            ds2_full = torch.zeros_like(inputs_embeds).masked_scatter(special_image_mask, ds2)
+            return inputs_embeds, ds0_full, ds1_full, ds2_full
+
+        inputs_embeds, ds0_full, ds1_full, ds2_full = torch.cond(
             image_features is None,
             image_features_is_none,
             image_features_is_not_none,
-            (inputs_embeds, image_features,)
+            (inputs_embeds, image_features, deepstack_features_0, deepstack_features_1, deepstack_features_2,)
         )
 
-        return inputs_embeds
+        return inputs_embeds, ds0_full, ds1_full, ds2_full
 
     def get_rope_index(
         self,

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/codes/modeling_qwen3_vl.py
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/codes/modeling_qwen3_vl.py
@@ -1105,15 +1105,17 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
             inputs_embeds = self.get_input_embeddings()(input_ids)
 
         if pixel_values is not None:
-            image_embeds = self.get_image_features(pixel_values, image_grid_thw)
-            image_embeds = torch.cat(image_embeds, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
+            # get_image_features returns (image_features, *deepstack_feats); the monolithic
+            # forward path only fuses the merged embedding, so take the first element.
+            image_embeds, *_ = self.get_image_features(pixel_values, image_grid_thw)
+            image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
             special_image_mask = input_ids == self.config.image_token_id
             special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
             inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_embeds)
 
         if pixel_values_videos is not None:
-            video_embeds = self.get_image_features(pixel_values_videos, video_grid_thw)
-            video_embeds = torch.cat(video_embeds, dim=0).to(inputs_embeds.device, inputs_embeds.dtype)
+            video_embeds, *_ = self.get_image_features(pixel_values_videos, video_grid_thw)
+            video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
             special_video_mask = input_ids == self.config.video_token_id
             special_video_mask = special_video_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
             inputs_embeds = inputs_embeds.masked_scatter(special_video_mask, video_embeds)

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/cpu_and_mobile/vision.json
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/cpu_and_mobile/vision.json
@@ -28,6 +28,24 @@
                     "dim_name": "num_logical_patches"
                 },
                 {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 1,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
+                },
+                {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 2,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
+                },
+                {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 3,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
+                },
+                {
                     "surgeon": "RenameInputDims",
                     "input_name": "image_grid_thw",
                     "dim_idx": 0,

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/cuda/vision.json
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/cuda/vision.json
@@ -28,6 +28,24 @@
                     "dim_name": "num_logical_patches"
                 },
                 {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 1,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
+                },
+                {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 2,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
+                },
+                {
+                    "surgeon": "RenameOutputDims",
+                    "output_idx": 3,
+                    "dim_idx": 0,
+                    "dim_name": "num_logical_patches"
+                },
+                {
                     "surgeon": "RenameInputDims",
                     "input_name": "image_grid_thw",
                     "dim_idx": 0,

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/optimize.py
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/optimize.py
@@ -68,11 +68,21 @@ def update_genai_config(output_dir: str = MODELS_DIR, device: str = "gpu"):
 
     session_options = {"log_id": "onnxruntime-genai", "provider_options": provider_options}
 
+    # Qwen3-VL DeepStack: vision emits one extra per-token feature per deepstack_visual_index
+    # (3 for the 4B model: vision layers [5, 11, 17]). embedding.onnx scatters them to full
+    # length; the decoder injects them after layers 0/1/2.
+    deepstack_features = [f"deepstack_features_{i}" for i in range(3)]
+    deepstack_full = [f"deepstack_{i}" for i in range(3)]
+
     # Embedding configuration
     config["model"]["embedding"] = {
         "filename": "embedding.onnx",
-        "inputs": {"input_ids": "input_ids", "image_features": "image_features"},
-        "outputs": {"inputs_embeds": "inputs_embeds"},
+        "inputs": {
+            "input_ids": "input_ids",
+            "image_features": "image_features",
+            "deepstack_features": deepstack_features,
+        },
+        "outputs": {"inputs_embeds": "inputs_embeds", "deepstack": deepstack_full},
         "session_options": session_options,
     }
 
@@ -85,9 +95,12 @@ def update_genai_config(output_dir: str = MODELS_DIR, device: str = "gpu"):
         "patch_size": 16,
         "window_size": 64,
         "inputs": {"pixel_values": "pixel_values", "image_grid_thw": "image_grid_thw"},
-        "outputs": {"image_features": "image_features"},
+        "outputs": {"image_features": "image_features", "deepstack_features": deepstack_features},
         "session_options": session_options,
     }
+
+    # Decoder consumes the full-length scattered DeepStack features (from embedding).
+    config["model"].setdefault("decoder", {}).setdefault("inputs", {})["deepstack"] = deepstack_full
 
     config["model"]["image_token_id"] = 151655
     config["model"]["video_token_id"] = 151656

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/user_script.py
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/user_script.py
@@ -20,12 +20,15 @@ def _load_base_model(model_path):
     """Load weights directly from safetensors, stripping 'model.' prefix,
     into our custom Qwen3VLModel without loading the full HF model."""
     from safetensors.torch import load_file
-    from huggingface_hub import hf_hub_download
     import glob
 
-    # Find safetensors file(s) in cache
-    config_path = hf_hub_download(model_path, 'config.json')
-    model_dir = os.path.dirname(config_path)
+    # Find safetensors file(s): support local directory or HF hub repo id
+    if model_path and os.path.isdir(model_path):
+        model_dir = model_path
+    else:
+        from huggingface_hub import hf_hub_download
+        config_path = hf_hub_download(model_path, 'config.json')
+        model_dir = os.path.dirname(config_path)
     st_files = sorted(glob.glob(os.path.join(model_dir, '*.safetensors')))
 
     # Load and strip 'model.' prefix, keeping native bfloat16 precision
@@ -66,11 +69,23 @@ def get_embedding_io_config(model_path=None):
     dynamic_axes = {
         "input_ids": {0: "batch_size", 1: "sequence_length"},
         "image_features": {0: "num_logical_patches"},
+        "deepstack_features_0": {0: "num_logical_patches"},
+        "deepstack_features_1": {0: "num_logical_patches"},
+        "deepstack_features_2": {0: "num_logical_patches"},
         "inputs_embeds": {0: "batch_size", 1: "sequence_length"},
+        "deepstack_0": {0: "batch_size", 1: "sequence_length"},
+        "deepstack_1": {0: "batch_size", 1: "sequence_length"},
+        "deepstack_2": {0: "batch_size", 1: "sequence_length"},
     }
     return {
-        "input_names": ["input_ids", "image_features"],
-        "output_names": ["inputs_embeds"],
+        "input_names": [
+            "input_ids",
+            "image_features",
+            "deepstack_features_0",
+            "deepstack_features_1",
+            "deepstack_features_2",
+        ],
+        "output_names": ["inputs_embeds", "deepstack_0", "deepstack_1", "deepstack_2"],
         "dynamic_axes": dynamic_axes,
     }
 
@@ -106,6 +121,15 @@ def get_embedding_dummy_inputs(model=None):
             out_hidden_size,
             dtype=torch.float32,  # fp32 to match embedding model export dtype
         ),
+        "deepstack_features_0": torch.randn(
+            num_logical_patches, out_hidden_size, dtype=torch.float32
+        ),
+        "deepstack_features_1": torch.randn(
+            num_logical_patches, out_hidden_size, dtype=torch.float32
+        ),
+        "deepstack_features_2": torch.randn(
+            num_logical_patches, out_hidden_size, dtype=torch.float32
+        ),
     }
 
     img_start_index = 3
@@ -127,6 +151,9 @@ def get_embedding_dummy_inputs(model=None):
     return {
         "input_ids": inputs["input_ids"],  # input_ids: torch.LongTensor
         "image_features": inputs["image_features"],  # image_features: Optional[torch.FloatTensor] = None,
+        "deepstack_features_0": inputs["deepstack_features_0"],
+        "deepstack_features_1": inputs["deepstack_features_1"],
+        "deepstack_features_2": inputs["deepstack_features_2"],
     }
 
 
@@ -150,7 +177,12 @@ def get_vision_io_config(model_path=None):
     """
     return {
         "input_names": ["pixel_values", "image_grid_thw"],
-        "output_names": ["image_features"],
+        "output_names": [
+            "image_features",
+            "deepstack_features_0",
+            "deepstack_features_1",
+            "deepstack_features_2",
+        ],
         "dynamic_shapes": {
             "pixel_values": {0: "num_patches"},
             "image_grid_thw": {0: "num_images"},

--- a/Qwen-Qwen3-VL-4B-Instruct/builtin/user_script.py
+++ b/Qwen-Qwen3-VL-4B-Instruct/builtin/user_script.py
@@ -31,6 +31,10 @@ def _load_base_model(model_path):
         model_dir = os.path.dirname(config_path)
     st_files = sorted(glob.glob(os.path.join(model_dir, '*.safetensors')))
 
+    # Build the model from the checkpoint's own config so a local variant/finetune
+    # loads consistently; fall back to the module-level Hub config for a bare repo id.
+    model_config = Qwen3VLConfig.from_pretrained(model_dir) if os.path.isdir(model_dir) else config
+
     # Load and strip 'model.' prefix, keeping native bfloat16 precision
     state_dict = {}
     for sf in st_files:
@@ -40,7 +44,7 @@ def _load_base_model(model_path):
                 state_dict[k[6:]] = v
 
     # Create custom model and load weights in bfloat16 (native dtype)
-    custom_model = Qwen3VLModel(config)
+    custom_model = Qwen3VLModel(model_config)
     result = custom_model.load_state_dict(state_dict, strict=False)
     if result.missing_keys:
         print(f"Warning: {len(result.missing_keys)} missing keys")


### PR DESCRIPTION
## Summary

Adds **DeepStack** support to the **Qwen3-VL-4B** export recipe so the exported ONNX models carry the intermediate vision features the model needs for fine-grained visual understanding (OCR, documents, diagrams, grounding).

Qwen3-VL's vision encoder emits, in addition to the merged image embedding, a small set of **intermediate hidden-state feature maps** ("DeepStack" features — one per entry in `vision_config.deepstack_visual_indexes`, i.e. 3 for the 4B model, from ViT layers `[5, 11, 17]`). These are scattered onto the image-token positions and injected into the decoder residual stream after the first few decoder layers (feature `i` → after layer `i`), matching Hugging Face's `Qwen3VLTextModel._deepstack_process`.

The previous recipe dropped these features (vision returned only the merged embedding, `update_genai_config` wrote no DeepStack fields), so the exported model lost accuracy. This PR wires them through the vision export, the embedding scatter, and `genai_config.json`.

This is the **export-side counterpart** to the onnxruntime-genai runtime PR that consumes these tensors; both are required for end-to-end DeepStack.

## How it works

The three sub-models exchange DeepStack tensors as follows:

```
vision.onnx      ->  deepstack_features_{i}   (per-token, image-token length)
embedding.onnx   ->  scatters them to full (batch, seq, hidden) -> deepstack_{i}
decoder.onnx     ->  adds deepstack_{i} into the residual after layer i
```

During generation there are no image tokens, so `embedding.onnx` emits all-zeros for `deepstack_{i}` and the decoder Adds become no-ops.

## Changes (`Qwen-Qwen3-VL-4B-Instruct/builtin`, 5 files)

- **`codes/modeling_qwen3_vl.py`**
  - `Qwen3VLVisionModel.forward`: capture the hidden states at `deepstack_visual_indexes`, run them through their per-index patch mergers, and return them **separately** as `(image_features, *deepstack_feats)` instead of folding them into the merged features.
  - `get_image_features`: propagate the tuple.
  - `get_fused_input_embeddings`: accept `deepstack_features_0/1/2`, `masked_scatter` each into full-length `(batch, seq, hidden)` zero tensors at image-token positions, and return `(inputs_embeds, deepstack_0, deepstack_1, deepstack_2)`.

- **`user_script.py`**
  - `get_vision_io_config`: add `deepstack_features_0/1/2` to vision output names.
  - `get_embedding_io_config`: add the DeepStack inputs/outputs and dynamic axes.
  - `get_embedding_dummy_inputs`: add matching dummy DeepStack tensors for tracing.
  - `_load_base_model`: accept a local model directory (not only an HF hub id).

- **`cpu_and_mobile/vision.json`, `cuda/vision.json`**
  - `RenameOutputDims` for the 3 new vision outputs (dim-0 → `num_logical_patches`).

- **`optimize.py`**
  - `update_genai_config`: emit the DeepStack tensor-name arrays — `vision.outputs.deepstack_features`, `embedding.inputs.deepstack_features`, `embedding.outputs.deepstack`, and `decoder.inputs.deepstack`.

## Validation

- Python byte-compiles; both `vision.json` files parse.
- **Functional test**: built the vision tower from the real HF config (random init) and confirmed it now returns `image_features` + one feature per `deepstack_visual_index` (3), all with matching shape; and that the embedding scatter fills **only** image-token positions (all other positions remain zero, so the decoder Adds are no-ops during generation).
- The runtime side has been validated end to end on an equivalently-exported Qwen3-VL-4B model (AI2D 81% ONNX INT4 vs 83% PyTorch FP32, within noise).

## Scope / notes

- Change is confined to the Qwen3-VL-4B recipe; no shared code is touched.
- A full `optimize.py` export run was not included here (requires the ~8GB base checkpoint); the model changes are covered by the functional test and by the previously-exported, runtime-validated model produced by the equivalent code.
