### PR TITLE
removed redundant rgb conversion in ministral model

### DIFF
--- a/mistralai-Ministral-3-3B-Instruct-2512/builtin/optimize.py
+++ b/mistralai-Ministral-3-3B-Instruct-2512/builtin/optimize.py
@@ -434,12 +434,6 @@ def update_genai_config(output_dir: str = MODELS_DIR, device: str = "cpu"):
                 },
                 {
                     "operation": {
-                        "name": "convert_to_rgb",
-                        "type": "ConvertRGB",
-                    }
-                },
-                {
-                    "operation": {
                         "name": "resize",
                         "type": "Resize",
                         "attrs": {


### PR DESCRIPTION
response to a customer bug where ministral was reporting incorrect colors